### PR TITLE
bug.68 - support navigation for content types created by plugins

### DIFF
--- a/services/navigation.js
+++ b/services/navigation.js
@@ -124,14 +124,15 @@ module.exports = {
       .map(({ key, available}) => {
         const item = strapi.contentTypes[key];
         const relatedField = (item.associations || []).find(_ => _.model === 'navigationitem');
-        const { uid, options, info, collectionName, apiName, plugin, kind } = item;
+        const { uid, options, info, collectionName, modelName, apiName, plugin, kind } = item;
         const { name, description } = info;
         const { isManaged, hidden, templateName } = options;
         const isSingle = kind === KIND_TYPES.SINGLE;
-        const endpoint = isSingle ? apiName : pluralize(apiName);
-        const relationName = utilsFunctions.singularize(apiName);
+        const pluralizeName = apiName ? apiName : modelName;
+        const endpoint = isSingle ? pluralizeName : pluralize(pluralizeName);
+        const relationName = utilsFunctions.singularize(pluralizeName);
         const relationNameParts = last(uid.split('.')).split('-');
-        const contentTypeName = relationNameParts.length > 1 ? relationNameParts.reduce((prev, curr) => `${prev}${upperFirst(curr)}`, '') : upperFirst(apiName);
+        const contentTypeName = relationNameParts.length > 1 ? relationNameParts.reduce((prev, curr) => `${prev}${upperFirst(curr)}`, '') : upperFirst(pluralizeName);
         const labelSingular = name || (upperFirst(relationNameParts.length > 1 ? relationNameParts.join(' ') : relationName));
         return {
           uid,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/68

## Summary

What does this PR do/solve? 

Support navigation for content types created by plugins

> PRs should be as small as they need to be, if this section starts becoming a novel you should _seriously_ consider breaking it up into multiple PRs

## Test Plan

How are you testing the work you're submitting?

Created content types by plugin and manually in content builder, both worked.
