### PR TITLE
Add option to render selected child of root nav

### DIFF
--- a/config/routes.json
+++ b/config/routes.json
@@ -47,6 +47,14 @@
       "config": {
         "policies": []
       }
+    },
+    {
+      "method": "GET",
+      "path": "/render/:idOrSlug/:childUIKey",
+      "handler": "navigation.renderChild",
+      "config": {
+        "policies": []
+      }
     }
   ]
 }

--- a/controllers/navigation.js
+++ b/controllers/navigation.js
@@ -57,6 +57,17 @@ module.exports = {
       menuOnly,
     );
   },
+  async renderChild(ctx) {
+    const { params, query = {} } = ctx;
+    const { type, menu: menuOnly } = query;
+    const { idOrSlug, childUIKey } = parseParams(params);
+    return await this.getService().renderChildren(
+      idOrSlug,
+      childUIKey,
+      type,
+      menuOnly
+    );
+  },
 
   post(ctx) {
     const { auditLog } = ctx;


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/76
## Summary

What does this PR do/solve? 

Added an option to filter out the children by the `uiRouterKey` for all of the types.

There is an option to distinguish between id/slug for the flat type to use strapi filtration.

## Test Plan

Base project with Postmann calls
