### PR TITLE
feat: add gql support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     environment:
       CODECOV_TOKEN: a9097475-0b5b-481f-8733-7b84574d583e
     docker:
-      - image: circleci/node:12.13.0
+      - image: circleci/node:14.17.2
     working_directory: ~/repo
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ inside the `attributes` section like in example below:
 ## Configuration
 To setup the plugin properly we recommend to put following snippet as part of `config/custom.js` or `config/<env>/custom.js` file. If you've got already configurations for other plugins stores by this way, use just the `navigation` part within exising `plugins` item.
 
-```
+```js
     ...
     plugins: {
       navigation: {
@@ -118,6 +118,23 @@ To setup the plugin properly we recommend to put following snippet as part of `c
     },
     ...
 ```
+
+## GQL
+To correctly configure GQL with navigation you should add in previous configurations add property `gql`.
+```js
+contentTypesNameFields: {....},
+gql: {
+    navigationItemRelated: 'union NavigationRelated = <your GQL related entities>',
+  },
+},
+```
+That property should contain union types which one will be used for definition GQL response when you fetch data:
+```gql
+master: Int
+items: [NavigationItem]
+related: NavigationRelated
+```
+
 
 ### Properties
 - `additionalFields` - Additional fields: 'audience', more in the future

--- a/config/schema.graphql.js
+++ b/config/schema.graphql.js
@@ -1,0 +1,205 @@
+const {get} = require('lodash');
+const NAVIGATION_DATE = `
+# SQL
+  created_at: String
+  updated_at: String
+# MONGO
+  createdAt: String
+  updatedAt: String
+`;
+
+const NAVIGATION_USER = `
+# SQL
+ created_by: String
+ updated_by: String
+# MONGO
+ createdBy: String
+ updatedBy: String
+`;
+
+const NAVIGATION = `
+ id: String!
+ name: String!
+ slug: String!
+ visible: Boolean!
+`;
+
+const getContentTypesNamesFields = () => {
+  const contentTypesNameFields = strapi.config.get('custom.plugins.navigation.contentTypesNameFields');
+  return Object.keys(contentTypesNameFields || {}).map(key => `${key}: [String]!`).join('\n');
+};
+
+const getNavigationRelated = () => {
+  const related = strapi.config.get('custom.plugins.navigation.gql.navigationItemRelated');
+  if (related) {
+    return related;
+  }
+  return `
+    type NavigationRelated { 
+      id: Int
+      title: String
+      name: String
+    }
+  `;
+};
+
+module.exports = {
+  // language=GraphQL
+  definition: `
+  enum NavigationRenderType {
+      FLAT,
+      TREE,
+      RFR
+  }
+  
+  ${getNavigationRelated()}
+
+
+  type NavigationItem { 
+    id: Int!
+    title: String!
+    type: String!
+    path: String
+    externalPath: String
+    uiRouterKey: String!
+    menuAttached: Boolean!
+    order: Int!
+    parent: Int
+    master: Int
+    items: [NavigationItem]
+    related: NavigationRelated
+    audience: [String]
+    ${NAVIGATION_DATE}
+    ${NAVIGATION_USER}
+  }
+
+  type Navigation { 
+    ${NAVIGATION}
+  }
+  
+  type NavigationDetails { 
+    ${NAVIGATION}  
+    items: [NavigationItem]!
+  }
+  
+  
+  type ContentTypesNameFields { 
+    default: [String!]!
+    ${getContentTypesNamesFields()}
+  }
+
+  type ContentTypes { 
+    uid: String!
+    name: String!
+    isSingle: Boolean!
+    collectionName: String!
+    contentTypeName: String!
+    label: String!
+    relatedField: String!
+    labelSingular: String!
+    endpoint: String!
+    available: Boolean!
+    visible: Boolean!
+  }
+
+  type NavigationConfig { 
+    allowedLevels: Int
+    availableAudience: [NavigationAudience]!
+    additionalFields: [String]!
+    contentTypesNameFields: ContentTypesNameFields
+    contentTypes: [ContentTypes] 
+  }
+
+  input CreateNavigationRelated {
+    ref: String!
+    field: String!
+    refId: String!
+  }
+  
+  input CreateNavigationItem {
+    title: String!
+    type: String!
+    path: String
+    externalPath: String
+    uiRouterKey: String!
+    menuAttached: Boolean!
+    order: Int!
+    parent: Int
+    master: Int
+    items: [CreateNavigationItem]
+    audience: [String]
+    related: CreateNavigationRelated
+  }
+
+  input CreateNavigation {
+    name: String!
+    items: [CreateNavigationItem]!
+  }
+  `,
+  query: `
+    renderNavigation(navigationIdOrSlug: String!, type: NavigationRenderType, menuOnly: Boolean): [NavigationItem]!
+    renderNavigationChild(id: String!, childUIKey: String!, type: NavigationRenderType, menuOnly: Boolean): [NavigationItem]!
+    getNavigation: [Navigation]!
+    configNavigation: NavigationConfig
+    getByIdNavigation(id: String!): NavigationItem
+  `,
+  type: {},
+  mutation: `
+    navigationCreate(newNavigation: CreateNavigation!): Navigation!
+    navigationUpdate(id: String!, navigation: CreateNavigation!): Navigation!
+  `,
+  resolver: {
+    Query: {
+      renderNavigation: {
+        resolverOf: 'plugins::navigation.navigation.render',
+        resolver(obj, options) {
+          const { navigationIdOrSlug, type, menuOnly } = options;
+          return strapi.plugins.navigation.services.navigation.render(navigationIdOrSlug, type, menuOnly);
+        },
+      },
+      renderNavigationChild: {
+        resolverOf: 'plugins::navigation.navigation.renderChild',
+        async resolver(obj, options) {
+          const { id, childUIKey, type, menuOnly } = options;
+          return strapi.plugins.navigation.services.navigation.renderChildren(id, childUIKey, type, menuOnly);
+        },
+      },
+      getNavigation: {
+        resolverOf: 'plugins::navigation.navigation.get',
+        resolver() {
+          return strapi.plugins.navigation.services.navigation.get();
+        },
+      },
+      configNavigation: {
+        resolverOf: 'plugins::navigation.navigation.config',
+        resolver() {
+          return strapi.plugins.navigation.services.navigation.config();
+        },
+      },
+      getByIdNavigation: {
+        resolverOf: 'plugins::navigation.navigation.getById',
+        async resolver(obj, options) {
+          const { id } = options;
+          return strapi.plugins.navigation.services.navigation.getById(id);
+        },
+      },
+    },
+    Mutation: {
+      navigationCreate: {
+        resolverOf: 'plugins::navigation.navigation.post',
+        resolver(obj, options) {
+          const { newNavigation } = options;
+          return strapi.plugins.navigation.services.navigation.post(newNavigation);
+        },
+      },
+      navigationUpdate: {
+        resolverOf: 'plugins::navigation.navigation.put',
+        resolver(obj, options) {
+          const { id, navigation } = options;
+          return  strapi.plugins.navigation.services.navigation.put(id, navigation);
+        },
+      },
+    },
+  },
+};
+

--- a/controllers/navigation.js
+++ b/controllers/navigation.js
@@ -34,24 +34,24 @@ module.exports = {
    * @return {Object}
    */
   async config() {
-    return await this.getService().config();
+    return this.getService().config();
   },
 
   async get() {
-    return await this.getService().get();
+    return this.getService().get();
   },
 
   async getById(ctx) {
     const { params } = ctx;
     const { id } = parseParams(params);
-    return await this.getService().getById(id);
+    return this.getService().getById(id);
   },
 
   async render(ctx) {
     const { params, query = {} } = ctx;
     const { type, menu: menuOnly } = query;
     const { idOrSlug } = parseParams(params);
-    return await this.getService().render(
+    return this.getService().render(
       idOrSlug,
       type,
       menuOnly,
@@ -61,7 +61,7 @@ module.exports = {
     const { params, query = {} } = ctx;
     const { type, menu: menuOnly } = query;
     const { idOrSlug, childUIKey } = parseParams(params);
-    return await this.getService().renderChildren(
+    return this.getService().renderChildren(
       idOrSlug,
       childUIKey,
       type,

--- a/services/navigation.js
+++ b/services/navigation.js
@@ -9,7 +9,8 @@ const {
   isEmpty,
   isObject,
   isNil,
-  isNumber,
+  toNumber,
+  isNaN,
   find,
   first,
   get,
@@ -103,16 +104,16 @@ module.exports = {
 
               if (isSingleType) {
                 if (isSingleTypeWithPublishFlow) {
-                  const itemsCountOrBypass = isSingleTypeWithPublishFlow ? 
+                  const itemsCountOrBypass = isSingleTypeWithPublishFlow ?
                     await strapi.query(uid).count({
                       _publicationState: 'live'
-                    }) : 
+                    }) :
                     true;
                   return returnType(itemsCountOrBypass !== 0);
                 }
                 const isAvailable = await strapi.query(uid).count();
                 return isAvailable === 1 ? returnType(true) : undefined;
-              } 
+              }
               return returnType(true);
             }
             return undefined;
@@ -199,7 +200,7 @@ module.exports = {
       .create({
         name,
         slug: slugify(name).toLowerCase(),
-        visible,
+        visible: !!visible,
       });
 
     return service
@@ -223,7 +224,7 @@ module.exports = {
         {
           name: entityNameHasChanged ? name : existingEntity.name,
           slug: entityNameHasChanged ? slugify(name).toLowerCase() : existingEntity.slug,
-          visible,
+          visible: !!visible,
         },
       );
     }
@@ -244,7 +245,7 @@ module.exports = {
     const { service } = utilsFunctions.extractMeta(
       strapi.plugins,
     );
-    const findById = isNumber(idOrSlug) || isUuid(idOrSlug);
+    const findById = !isNaN(toNumber(idOrSlug)) || isUuid(idOrSlug);
     const criteria = findById ? { id: idOrSlug } : { slug: idOrSlug };
     const itemCriteria = menuOnly ? { menuAttached: true } : {};
 
@@ -258,7 +259,7 @@ module.exports = {
     menuOnly = false
   ) => {
     const { service } = utilsFunctions.extractMeta(strapi.plugins);
-    const findById = isNumber(idOrSlug) || isUuid(idOrSlug);
+    const findById = !isNaN(toNumber(idOrSlug)) || isUuid(idOrSlug);
     const criteria = findById ? { id: idOrSlug } : { slug: idOrSlug };
     const filter = type === renderType.FLAT ? null : childUIKey;
 
@@ -298,7 +299,7 @@ module.exports = {
       const { contentTypes, contentTypesNameFields } = await service.config();
       const getTemplateName = await utilsFunctions.templateNameFactory(items, strapi, contentTypes)
 
-      switch (type) {
+      switch (type?.toLowerCase()) {
         case renderType.TREE:
         case renderType.RFR:
           const itemParser = (item, path = '', field) => {
@@ -307,6 +308,7 @@ module.exports = {
             const slug = isString(parentPath) ? slugify((first(parentPath) === '/' ? parentPath.substring(1) : parentPath).replace(/\//g, '-')) : undefined;
             const lastRelated = item.related ? last(item.related) : undefined;
             return {
+              id: item.id,
               title: utilsFunctions.composeItemTitle(item, contentTypesNameFields, contentTypes),
               menuAttached: item.menuAttached,
               path: isExternal ? item.externalPath : parentPath,
@@ -350,8 +352,9 @@ module.exports = {
             .filter(utilsFunctions.filterOutUnpublished)
             .map((item) => ({
               ...sanitizeEntity(item, { model: itemModel }),
+              audience: item.audience?.map(_ => _.key),
               title: utilsFunctions.composeItemTitle(item, contentTypesNameFields, contentTypes),
-              related: item.related,
+              related: last(item.related),
               items: null,
             }));
       }
@@ -359,7 +362,7 @@ module.exports = {
     throw strapi.errors.notFound();
   },
 
-  renderTree: ({ 
+  renderTree: ({
     items = [],
     id = null,
     field = 'parent',
@@ -395,7 +398,7 @@ module.exports = {
       const { items: itemChilds, ...itemProps } = item;
       const itemNav = service.renderRFRNav(itemProps);
       const itemPage = service.renderRFRPage({
-        item: itemProps, 
+        item: itemProps,
         parent,
       });
 
@@ -429,15 +432,15 @@ module.exports = {
 
       if (!isEmpty(itemChilds)) {
         const { nav: nestedNavs } = service.renderRFR({
-          items: itemChilds, 
-          parent: itemPage.id, 
+          items: itemChilds,
+          parent: itemPage.id,
           parentNavItem: itemNav,
           contentTypes,
         });
         const { pages: nestedPages } = service.renderRFR({
-          items: itemChilds.filter(child => child.type === itemType.INTERNAL), 
-          parent: itemPage.id, 
-          parentNavItem: itemNav, 
+          items: itemChilds.filter(child => child.type === itemType.INTERNAL),
+          parent: itemPage.id,
+          parentNavItem: itemNav,
           contentTypes,
         });
         pages = {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/54

## Summary

What does this PR do/solve? 
Add GQL support

> PRs should be as small as they need to be, if this section starts becoming a novel you should _seriously_ consider breaking it up into multiple PRs

## Test Plan
Example queries:
```gql
query {
  renderNavigation(navigationIdOrSlug: "main-navigation", type: TREE) { 
  	id
    title
    type
    path
    externalPath
    uiRouterKey
    menuAttached
    parent
    master
    related {
      id
    }
    audience
    items {
      id
      items {
        id
      }
    }
    items {
      id
    }
  }
  
  getNavigation {
    id
    name
    slug
  }
  
  configNavigation {
    allowedLevels
    additionalFields
    availableAudience {
      id
      name
    }
    contentTypesNameFields {
      default
      page
      pages
    }
    contentTypes {
      uid
      name
      collectionName
    }
  }
  getByIdNavigation(id:"1"){
    id
    items {
      id
      items {
        id
      }
    }
  }
  
  renderNavigationChild(id: "1", childUIKey: "test2", type: TREE){
    id
    items {
      id
    }
  }
}

 mutation {
  navigationCreate(newNavigation:{name:"Test1", items:[{title:"TEST2", type: "INTERNAL", uiRouterKey:"lol", menuAttached: false, order: 1}]}) {
   id
 }
   navigationUpdate(id: "7", navigation: {name: "UpdateTest1", items:[]}) {
     id
   }
 }
```
How are you testing the work you're submitting?
