### PR TITLE
Filters out hidden fields from related objects

### DIFF
--- a/services/navigation.js
+++ b/services/navigation.js
@@ -185,7 +185,8 @@ module.exports = {
         _limit: -1,
         _sort: 'order:asc',
       });
-    const entities = await this.getRelatedItems(entityItems);
+    let entities = await this.getRelatedItems(entityItems);
+    entities = entities.map((_) => sanitizeEntity(_, { model: itemModel }));
     return {
       ...sanitizeEntity(entity,
         { model: masterModel },
@@ -301,7 +302,8 @@ module.exports = {
       if (!entities) {
         return [];
       }
-      const items = await this.getRelatedItems(entities);
+      let items = await this.getRelatedItems(entities);
+      items = items.map((_) => sanitizeEntity(_, { model: itemModel }));
       const { contentTypes, contentTypesNameFields } = await service.config();
 
       switch (type?.toLowerCase()) {


### PR DESCRIPTION
## Summary

Hidden fields like "created_by" where not being filtered out of related objects. Resulting in objects containing hashed passwords & reset tokens. This change replaces ```"created_by": Object``` with ```"created_by": Id```.

## Test Plan

- Checked if project test had not failed
- Applied change in my personal project
- Removed ignore files/folders like .cache/, build/
- Ran npm run develop
- Set rights for  "get", "getById", "render" endpoints to public
- Validated results for "get", "getById", "render" with Postman
