### PR TITLE
docs: fix default content type UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ To setup the plugin properly we recommend to put following snippet as part of `c
             enabled: true,
             config: {
                 additionalFields: ['audience'],
-                contentTypes: ['api::page::page'],
+                contentTypes: ['api::page.page'],
                 contentTypesNameFields: {
                     'page': ['title']
                 },


### PR DESCRIPTION
## Summary

What does this PR do/solve? 

> Documented content type UID in example config is wrong. This fixes it to the correct format.