### PR TITLE
feat: render by path [CU-21ungpa]

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,20 @@ For any role different than **Super Admin**, to access the **Navigation panel** 
 
 ## 🕸️ Public API specification
 
+### Query Params 
+
+- `type` - Enum value representing structure type of returned navigation 
+
+    **Example URL**: `https://localhost:1337/api/navigation/render/1?type=FLAT`
+
+- `menu` - Boolean value for querying only navigation items that are attached to menu should be rendered eg.
+
+    **Example URL**: `https://localhost:1337/api/navigation/render/1?menu=true`
+
+- `path` - String value for querying navigation items by its path 
+
+    **Example URL**: `https://localhost:1337/api/navigation/render/1?path=/home/about-us`
+
 ### Render
 
 `GET <host>/api/navigation/render/<idOrSlug>?type=<type>`

--- a/__mocks__/strapi.js
+++ b/__mocks__/strapi.js
@@ -48,7 +48,7 @@ const itemModelMock = {
         id: 1,
         title: "home",
         type: "INTERNAL",
-        path: "home1",
+        path: "home",
         externalPath: null,
         uiRouterKey: "home",
         menuAttached: true,

--- a/server/controllers/navigation.js
+++ b/server/controllers/navigation.js
@@ -74,13 +74,14 @@ module.exports = ({strapi}) => ({
   },
   async render(ctx) {
     const { params, query = {} } = ctx;
-    const { type, menu: menuOnly } = query;
+    const { type, menu: menuOnly, path: rootPath } = query;
     const { idOrSlug } = parseParams(params);
-    return getService().render(
+    return getService().render({
       idOrSlug,
       type,
       menuOnly,
-    );
+      rootPath
+    });
   },
   async renderChild(ctx) {
     const { params, query = {} } = ctx;

--- a/server/graphql/queries/render-navigation.js
+++ b/server/graphql/queries/render-navigation.js
@@ -5,11 +5,12 @@ module.exports = ({ strapi, nexus }) => {
 		args: {
 			navigationIdOrSlug: nonNull(stringArg()),
 			type: 'NavigationRenderType',
-			menuOnly: booleanArg()
+			menuOnly: booleanArg(),
+			path: stringArg(),
 		},
 		resolve(obj, args) {
-			const { navigationIdOrSlug: idOrSlug, type, menuOnly } = args;
-			return strapi.plugin('navigation').service('navigation').render({idOrSlug, type, menuOnly});
+			const { navigationIdOrSlug: idOrSlug, type, menuOnly, path: rootPath } = args;
+			return strapi.plugin('navigation').service('navigation').render({idOrSlug, type, menuOnly, rootPath});
 		},
 	};
 }

--- a/server/graphql/queries/render-navigation.js
+++ b/server/graphql/queries/render-navigation.js
@@ -8,8 +8,8 @@ module.exports = ({ strapi, nexus }) => {
 			menuOnly: booleanArg()
 		},
 		resolve(obj, args) {
-			const { navigationIdOrSlug, type, menuOnly } = args;
-			return strapi.plugin('navigation').service('navigation').render(navigationIdOrSlug, type, menuOnly);
+			const { navigationIdOrSlug: idOrSlug, type, menuOnly } = args;
+			return strapi.plugin('navigation').service('navigation').render({idOrSlug, type, menuOnly});
 		},
 	};
 }

--- a/server/services/__tests__/functions.test.js
+++ b/server/services/__tests__/functions.test.js
@@ -1,0 +1,48 @@
+const { setupStrapi } = require('../../../__mocks__/strapi');
+const utilsFunctionsFactory = require('../utils/functions');
+
+describe('Utilities functions', () => {
+	beforeAll(async () => {
+		setupStrapi();
+	});
+
+	describe('Path rendering functions', () => {
+		it('Can build nested path structure', async () => {
+			const utilsFunctions = utilsFunctionsFactory({ strapi });
+			const { itemModel } = utilsFunctions.extractMeta(strapi.plugins);
+			const rootPath = '/home/side';
+			const entities = await strapi
+				.query(itemModel.uid)
+				.findMany({
+					where: {
+						master: 1
+					}
+				});
+			const nested = utilsFunctions.buildNestedPaths({ items: entities });
+
+			expect(nested.length).toBe(2);
+			expect(nested[1].path).toBe(rootPath);
+		});
+
+		it('Can filter items by path', async () => {
+			const utilsFunctions = utilsFunctionsFactory({ strapi });
+			const { itemModel } = utilsFunctions.extractMeta(strapi.plugins);
+			const rootPath = '/home/side';
+			const entities = await strapi
+				.query(itemModel.uid)
+				.findMany({
+					where: {
+						master: 1
+					}
+				});
+			const {
+				root,
+				items
+			} = utilsFunctions.filterByPath(entities, rootPath);
+
+			expect(root).toBeDefined();
+			expect(root.path).toBe(rootPath);
+			expect(items.length).toBe(1)
+		});
+	});
+});

--- a/server/services/__tests__/navigation.test.js
+++ b/server/services/__tests__/navigation.test.js
@@ -26,7 +26,7 @@ describe('Navigation services', () => {
   describe('Render navigation', () => {
     it('Can render branch in flat format', async () => {
       const service = strapi.plugin('navigation').service('navigation');
-      const result = await service.render(1);
+      const result = await service.render({ idOrSlug: 1 });
 
       expect(result).toBeDefined()
       expect(result.length).toBe(2)
@@ -34,7 +34,10 @@ describe('Navigation services', () => {
 
     it('Can render branch in tree format', async () => {
       const service = strapi.plugin('navigation').service('navigation');
-      const result = await service.render(1, "TREE");
+      const result = await service.render({
+        idOrSlug: 1,
+        type: "TREE"
+      });
 
       expect(result).toBeDefined()
       expect(result.length).toBeGreaterThan(0)
@@ -42,7 +45,10 @@ describe('Navigation services', () => {
 
     it('Can render branch in rfr format', async () => {
       const service = strapi.plugin('navigation').service('navigation');
-      const result = await service.render(1, "RFR");
+      const result = await service.render({
+        idOrSlug: 1,
+        type: "RFR"
+      });
 
       expect(result).toBeDefined()
       expect(result.length).toBeGreaterThan(0)
@@ -50,7 +56,11 @@ describe('Navigation services', () => {
 
     it('Can render only menu attached elements', async () => {
       const service = strapi.plugin('navigation').service('navigation');
-      const result = await service.render(1, "FLAT", true);
+      const result = await service.render({
+        idOrSlug: 1,
+        type: "FLAT",
+        menuOnly: true.valueOf,
+      });
 
       expect(result).toBeDefined()
       expect(result.length).toBe(1)

--- a/server/services/__tests__/navigation.test.js
+++ b/server/services/__tests__/navigation.test.js
@@ -65,6 +65,18 @@ describe('Navigation services', () => {
       expect(result).toBeDefined()
       expect(result.length).toBe(1)
     });
+
+    it('Can render branch by path', async () => {
+      const service = strapi.plugin('navigation').service('navigation');
+      const result = await service.render({
+        idOrSlug: 1,
+        type: "FLAT",
+        rootPath: '/home/side'
+      });
+
+      expect(result).toBeDefined();
+      expect(result.length).toBe(1);
+    });
   });
 
   describe('Render child', () => {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/146

## Summary

What does this PR do/solve? 

> Adds the possibility to render subtree of navigation by providing path param 

- [x] REST API 
- [x] GraphQL
- [x] Update documentation

## Test Plan

#### Test Scenarios 

- Render navigation tree without providing path param
- Render the whole navigation tree by providing a root path
- Render a subtree of navigation by providing a path to a nested item

#### Test outcomes

- Rendering should return proper items from the navigation tree 
- Rendering works both in REST API and GraphQL
- Rendering works for all render types (tree, rfr and flat)