### PR TITLE
fix: no entity labels [CU-23kucmz]

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/index.js
+++ b/admin/src/pages/View/components/NavigationItemForm/index.js
@@ -164,8 +164,8 @@ const NavigationItemForm = ({
         key: get(item, 'id'),
         metadatas: {
           intlLabel: {
-            id: label || " ",
-            defaultMessage: label || " ",
+            id: label || `${item.__collectionUid} ${item.id}`,
+            defaultMessage: label || `${item.__collectionUid} ${item.id}`,
           }
         },
         value: item.id,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/153

## Summary

What does this PR do/solve? 

Fixes bug where no labels were displayed in entity dropdown on navigation item form. When no label is available the default label will be created. 

## Test Plan

- Create content type with no field of `"title"`, `"name"` or `"subject"`
- Try to add this content type to a new navigation item
- Form should have entities dropdown filled with default labels