### PR TITLE
fix: isArray not defined error in some use cases

### DIFF
--- a/server/services/utils/functions.js
+++ b/server/services/utils/functions.js
@@ -7,6 +7,7 @@ const {
   isString,
   get,
   isNil,
+  isArray
 } = require('lodash');
 
 const { type: itemType } = require('../../content-types/navigation-item/lifecycle');


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/159>

## Summary

PR fixes the isArray error mentioned in the ticket above.

## Test Plan

Tested on a fresh installation by both modifying functions.js in node_modules, and installing the forked git repo directly in package.json