### PR TITLE
feat: drag and drop [CU-21mynz7]

### DIFF
--- a/admin/src/components/Item/ItemCardHeader/index.js
+++ b/admin/src/components/Item/ItemCardHeader/index.js
@@ -4,13 +4,13 @@ import { Flex } from '@strapi/design-system/Flex';
 import { IconButton } from '@strapi/design-system/IconButton';
 import { Typography } from '@strapi/design-system/Typography';
 import { Icon } from '@strapi/design-system/Icon';
-import { Pencil, Trash, Refresh } from '@strapi/icons/';
+import { Pencil, Trash, Refresh, Drag } from '@strapi/icons/';
 
 import Wrapper from './Wrapper';
 import ItemCardBadge from '../ItemCardBadge';
 import { getMessage } from '../../../utils';
 
-const ItemCardHeader = ({ title, path, icon, removed, onItemRemove, onItemEdit, onItemRestore }) => {
+const ItemCardHeader = ({ title, path, icon, removed, onItemRemove, onItemEdit, onItemRestore, dragRef }) => {
 	return (
 		<Wrapper>
 			<Flex alignItems="center">
@@ -36,7 +36,10 @@ const ItemCardHeader = ({ title, path, icon, removed, onItemRemove, onItemEdit, 
 				<IconButton disabled={removed} onClick={onItemEdit} label="Edit" icon={<Pencil />} />
 				{removed ?
 					<IconButton onClick={onItemRestore} label="Restore" icon={<Refresh />} /> :
-					<IconButton onClick={onItemRemove} label="Remove" icon={<Trash />} />
+					<>
+						<IconButton ref={dragRef} label="Drag" icon={<Drag />} />
+						<IconButton onClick={onItemRemove} label="Remove" icon={<Trash />} />
+					</>
 				}
 			</Flex>
 		</Wrapper>

--- a/admin/src/components/Item/index.js
+++ b/admin/src/components/Item/index.js
@@ -1,6 +1,8 @@
+import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
-import { isEmpty, isNumber } from 'lodash';
+import { useDrag, useDrop } from 'react-dnd';
+import { getEmptyImage } from 'react-dnd-html5-backend';
+import { drop, isEmpty, isNumber } from 'lodash';
 
 import { Box } from '@strapi/design-system/Box';
 import { Card, CardBody } from '@strapi/design-system/Card';
@@ -18,7 +20,7 @@ import Wrapper from './Wrapper';
 import { extractRelatedItemLabel } from '../../pages/View/utils/parsers';
 import ItemCardBadge from './ItemCardBadge';
 import { ItemCardRemovedOverlay } from './ItemCardRemovedOverlay';
-import { getMessage } from '../../utils';
+import { getMessage, ItemTypes } from '../../utils';
 
 const Item = (props) => {
   const {
@@ -33,6 +35,7 @@ const Item = (props) => {
     onItemRemove,
     onItemRestore,
     onItemEdit,
+    onItemReOrder,
     error,
     displayChildren,
     config = {},
@@ -60,73 +63,124 @@ const Item = (props) => {
   const relatedTypeLabel = relatedRef?.labelSingular;
   const relatedBadgeColor = isPublished ? 'success' : 'secondary';
 
+  const dragRef = useRef(null);
+  const dropRef = useRef(null);
+  const previewRef = useRef(null);
+
+  const [, drop] = useDrop({
+    accept: `${ItemTypes.NAVIGATION_ITEM}_${levelPath}`,
+    hover(hoveringItem, monitor) {
+      const dragIndex = hoveringItem.order;
+      const dropIndex = item.order;
+
+      // Don't replace items with themselves
+      if (dragIndex === dropIndex) {
+        return;
+      }
+
+      const hoverBoundingRect = dropRef.current.getBoundingClientRect();
+      const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+      const clientOffset = monitor.getClientOffset();
+      const hoverClientY = clientOffset.y - hoverBoundingRect.top;
+
+      // Place the hovering item before or after the drop target
+      const isAfter = hoverClientY > hoverMiddleY;
+      const newOrder = isAfter ? item.order + 0.5 : item.order - 0.5;
+
+      onItemReOrder({ ...hoveringItem }, newOrder);
+    },
+    collect: monitor => ({
+      isOverCurrent: monitor.isOver({ shallow: true }),
+    })
+  });
+
+  const [{ isDragging }, drag, dragPreview] = useDrag({
+    type: `${ItemTypes.NAVIGATION_ITEM}_${levelPath}`,
+    item: () => {
+      return { ...item };
+    },
+    collect: monitor => ({
+      isDragging: monitor.isDragging(),
+    }),
+  });
+
+  const refs = {
+    dragRef: drag(dragRef),
+    dropRef: drop(dropRef),
+    previewRef: dragPreview(previewRef),
+  }
+
   return (
-    <Wrapper level={level} isLast={isLast}>
+    <Wrapper level={level} isLast={isLast} style={{ opacity: isDragging ? 0.2 : 1 }} ref={refs ? refs.dropRef : null} >
       <Card style={{ width: "728px", zIndex: 1, position: "relative", overflow: 'hidden' }}>
-        { removed && (<ItemCardRemovedOverlay />) }
-        <CardBody>
-          <ItemCardHeader
-            title={title}
-            path={isExternal ? externalPath : absolutePath}
-            icon={isExternal ? Earth : LinkIcon }
-            onItemRemove={() => onItemRemove({
-              ...item,
-              relatedRef,
-            })}
-            onItemEdit={() => onItemEdit({
-              ...item,
-              isMenuAllowedLevel,
-              isParentAttachedToMenu,
-            }, levelPath, isParentAttachedToMenu)}
-            onItemRestore={() => onItemRestore({
-              ...item,
-              relatedRef,
-            })}
-            removed={removed}
-          />
-        </CardBody>
-        <Divider />
-        { !isExternal && (<CardBody style={{ margin: '8px' }}>
-          <Flex style={{ width: '100%' }} direction="row" alignItems="center" justifyContent="space-between">
-            <TextButton
-              disabled={removed}
-              startIcon={<Plus />}
-              onClick={(e) => onItemLevelAdd(e, viewId, isNextMenuAllowedLevel, absolutePath, menuAttached)}
-            >
-              <Typography variant="pi" fontWeight="bold" textColor={removed ? "neutral600" : "primary600"}>
-                {getMessage("components.navigationItem.action.newItem")}
-              </Typography>
-            </TextButton>
-            { relatedItemLabel && (<Box>
+        {removed && (<ItemCardRemovedOverlay />)}
+        <div ref={refs.previewRef}>
+          <CardBody>
+            <ItemCardHeader
+              title={title}
+              path={isExternal ? externalPath : absolutePath}
+              icon={isExternal ? Earth : LinkIcon}
+              onItemRemove={() => onItemRemove({
+                ...item,
+                relatedRef,
+              })}
+              onItemEdit={() => onItemEdit({
+                ...item,
+                isMenuAllowedLevel,
+                isParentAttachedToMenu,
+              }, levelPath, isParentAttachedToMenu)}
+              onItemRestore={() => onItemRestore({
+                ...item,
+                relatedRef,
+              })}
+              dragRef={refs.dragRef}
+              removed={removed}
+            />
+          </CardBody>
+          <Divider />
+          {!isExternal && (<CardBody style={{ margin: '8px' }}>
+            <Flex style={{ width: '100%' }} direction="row" alignItems="center" justifyContent="space-between">
+              <TextButton
+                disabled={removed}
+                startIcon={<Plus />}
+                onClick={(e) => onItemLevelAdd(e, viewId, isNextMenuAllowedLevel, absolutePath, menuAttached)}
+              >
+                <Typography variant="pi" fontWeight="bold" textColor={removed ? "neutral600" : "primary600"}>
+                  {getMessage("components.navigationItem.action.newItem")}
+                </Typography>
+              </TextButton>
+              {relatedItemLabel && (<Box>
                 <ItemCardBadge
                   borderColor={`${relatedBadgeColor}200`}
                   backgroundColor={`${relatedBadgeColor}100`}
                   textColor={`${relatedBadgeColor}600`}
                   className="action"
                   small
-                  >
-                {getMessage({
-                  id: `components.navigationItem.badge.${isPublished ? 'published' : 'draft'}`, props: {
-                    type: relatedTypeLabel
-                  }
-                })}
+                >
+                  {getMessage({
+                    id: `components.navigationItem.badge.${isPublished ? 'published' : 'draft'}`, props: {
+                      type: relatedTypeLabel
+                    }
+                  })}
                 </ItemCardBadge>
                 <Typography variant="pi" fontWeight="bold" textColor="neutral600">
-                  { relatedItemLabel }
-                  <Link 
-                    to={`/content-manager/collectionType/${relatedRef?.__collectionUid}/${relatedRef?.id}`} 
+                  {relatedItemLabel}
+                  <Link
+                    to={`/content-manager/collectionType/${relatedRef?.__collectionUid}/${relatedRef?.id}`}
                     endIcon={<ArrowRight />}>&nbsp;</Link>
                 </Typography>
               </Box>)
-            }
-          </Flex>
-        </CardBody>)}
+              }
+            </Flex>
+          </CardBody>)}
+        </div>
       </Card>
       {hasChildren && !removed && <List
         onItemLevelAdd={onItemLevelAdd}
         onItemRemove={onItemRemove}
         onItemEdit={onItemEdit}
         onItemRestore={onItemRestore}
+        onItemReOrder={onItemReOrder}
         error={error}
         allowedLevels={allowedLevels}
         isParentAttachedToMenu={menuAttached}
@@ -159,9 +213,10 @@ Item.propTypes = {
   onItemRestore: PropTypes.func.isRequired,
   onItemLevelAdd: PropTypes.func.isRequired,
   onItemRemove: PropTypes.func.isRequired,
+  onItemReOrder: PropTypes.func.isRequired,
   config: PropTypes.shape({
-    contentTypes: PropTypes.array.isRequired, 
-    contentTypesNameFields: PropTypes.object.isRequired, 
+    contentTypes: PropTypes.array.isRequired,
+    contentTypesNameFields: PropTypes.object.isRequired,
   }).isRequired
 };
 

--- a/admin/src/components/NavigationItemList/index.js
+++ b/admin/src/components/NavigationItemList/index.js
@@ -15,6 +15,7 @@ const List = ({
   onItemLevelAdd,
   onItemRemove,
   onItemRestore,
+  onItemReOrder,
   displayFlat,
   contentTypes,
   contentTypesNameFields,
@@ -36,6 +37,7 @@ const List = ({
           onItemLevelAdd={onItemLevelAdd}
           onItemRemove={onItemRemove}
           onItemEdit={onItemEdit}
+          onItemReOrder={onItemReOrder}
           error={error}
           displayChildren={displayFlat}
           config={{
@@ -57,6 +59,7 @@ List.propTypes = {
   onItemRemove: PropTypes.func.isRequired,
   onItemRestore: PropTypes.func.isRequired,
   onItemRestore: PropTypes.func.isRequired,
+  onItemReOrder: PropTypes.func.isRequired,
   contentTypes: PropTypes.array.isRequired,
   contentTypesNameFields: PropTypes.object.isRequired
 };

--- a/admin/src/pages/View/index.js
+++ b/admin/src/pages/View/index.js
@@ -120,6 +120,13 @@ const View = () => {
   }, []);
   const filteredList = !isSearchEmpty ? filteredListFactory(changedActiveNavigation.items, (item) => item?.title.includes(searchValue)) : [];
 
+  const handleItemReOrder = (item, newOrder) => {
+    handleSubmitNavigationItem({
+      ...item,
+      order: newOrder,
+    })
+  }
+
   const handleItemRemove = (item) => {
     handleSubmitNavigationItem({
       ...item,
@@ -206,6 +213,7 @@ const View = () => {
                 onItemRemove={handleItemRemove}
                 onItemEdit={handleItemEdit}
                 onItemRestore={handleItemRestore}
+                onItemReOrder={handleItemReOrder}
                 displayFlat={!isSearchEmpty}
                 root
                 error={error}

--- a/admin/src/utils/index.js
+++ b/admin/src/utils/index.js
@@ -3,7 +3,7 @@ import { isString } from 'lodash';
 
 import pluginId from '../pluginId';
 
-const getMessage = (input, defaultMessage = '', inPluginScope = true) => {
+export const getMessage = (input, defaultMessage = '', inPluginScope = true) => {
     const { formatMessage } = useIntl();
     let formattedId = ''
     if (isString(input)) {
@@ -17,4 +17,6 @@ const getMessage = (input, defaultMessage = '', inPluginScope = true) => {
     }, input?.props || undefined)
 };
 
-export { getMessage };
+export const ItemTypes = {
+    NAVIGATION_ITEM: 'navigationItem'
+}


### PR DESCRIPTION
## Summary

What does this PR do/solve? 
> Introduces drag and drop functionality. Items can change order as long as they are at the same level. 

## Test Plan

How are you testing the work you're submitting?
- It should be possible to drag items around
- It should only be possible to drop items within the same level
- Items order should be saved and after refresh should be the same 
- Dropping the hovering item on the upper part of the target item should place it before the target
- Dropping the hovering item on the lower part of the target item should place it after the target
