### PR TITLE
fix: empty title [CU-2456ye4]

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/index.js
+++ b/admin/src/pages/View/components/NavigationItemForm/index.js
@@ -80,8 +80,10 @@ const NavigationItemForm = ({
     const sanitizedType = purePayload.type || navigationItemType.INTERNAL;
     const relatedId = related
     const relatedCollectionType = relatedType;
+    const title = payload.title || relatedSelectOptions.find(v => v.key == relatedId)?.label
     return {
       ...purePayload,
+      title,
       menuAttached: isNil(menuAttached) ? false : menuAttached,
       type: sanitizedType,
       path: sanitizedType === navigationItemType.INTERNAL ? purePayload.path : undefined,


### PR DESCRIPTION
## Summary

What does this PR do/solve? 

> Fixes empty navigation item bug.

## Test Plan

The title, when left empty, should be filled with data from a related field.
