### PR TITLE
No whitespace in `navigationItemRelated` Graphql

### DIFF
--- a/admin/src/pages/SettingsPage/index.js
+++ b/admin/src/pages/SettingsPage/index.js
@@ -55,7 +55,7 @@ const SettingsPage = () => {
     additionalFields: audienceFieldChecked ? [navigationItemAdditionalFields.AUDIENCE] : [],
     allowedLevels: allowedLevels,
     gql: {
-      navigationItemRelated: selectedContentTypes.map(uid => allContentTypes.find(ct => ct.uid === uid).info.displayName)
+      navigationItemRelated: selectedContentTypes.map(uid => allContentTypes.find(ct => ct.uid === uid).info.displayName.replace(/\s+/g, ''))
     }
   });
 


### PR DESCRIPTION
## Ticket

This is a simple change and I just created the PR

## Summary

Graphql type names can't contain whitespaces. However, in Strapi the display name is a beautified, and human-friendly version of the content type which may contain spaces. This PR ust removes them.

For example, a content type called "Policy Page" will become "PolicyPage" which is the Graphql type that strapi will generate

## Test Plan

Pre-patched version

1. Create a content type called "Policy Page" and add it to navigation
2. On restart, Strapi will crash and show this error `Expected Policy Page to be a objectType, saw GraphQLScalarType`

This is because the config saved includes an invalid Graphql type name

After the patch, everything works fine
