### PR TITLE
ordered trees

### DIFF
--- a/server/services/navigation.js
+++ b/server/services/navigation.js
@@ -428,6 +428,7 @@ module.exports = ({ strapi }) => {
                 id: item.id,
                 title: utilsFunctions.composeItemTitle(item, contentTypesNameFields, contentTypes),
                 menuAttached: item.menuAttached,
+                order: item.order,
                 path: isExternal ? item.externalPath : parentPath,
                 type: item.type,
                 uiRouterKey: item.uiRouterKey,
@@ -511,7 +512,10 @@ module.exports = ({ strapi }) => {
         .filter(utilsFunctions.filterOutUnpublished)
         .map(item => itemParser({
           ...item,
-        }, path, field));
+        }, path, field))
+        .sort((x, y) => {
+          return x.order - y.order;
+       });
     },
 
     renderRFR({ items, parent = null, parentNavItem = null, contentTypes = [] }) {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/186

## Summary

What does this PR do/solve? 

> Graphql requests of TREE rendering with order field in the request don't fail any more
> All API requests now returned ordered trees as set in Strapi

## Test Plan

1. Create a navigation item in Strapi
2. Change ordering of items using drag&drop
3. Test the ordering is right in API responses
