### PR TITLE
feat: issue #184 support for plugin content types

### DIFF
--- a/admin/src/pages/SettingsPage/index.js
+++ b/admin/src/pages/SettingsPage/index.js
@@ -31,6 +31,7 @@ import { navigationItemAdditionalFields } from '../View/utils/enums';
 import ConfirmationDialog from '../../components/ConfirmationDialog';
 import RestartAlert from '../../components/RestartAlert';
 import { getMessage } from '../../utils';
+import { isContentTypeEligible, resolveGlobalLikeId } from './utils/functions';
 
 const SettingsPage = () => {
   const { lockApp, unlockApp } = useOverlayBlocker();
@@ -56,13 +57,7 @@ const SettingsPage = () => {
     additionalFields: audienceFieldChecked ? [navigationItemAdditionalFields.AUDIENCE] : [],
     allowedLevels: allowedLevels,
     gql: {
-      navigationItemRelated: selectedContentTypes.map(uid => {
-        const singularName = allContentTypes.find(ct => ct.uid === uid).info.singularName;
-        const globalIdLike = singularName.split('-')
-          .map(_ => capitalize(_))
-          .join('')
-        return globalIdLike;
-      })
+      navigationItemRelated: selectedContentTypes.map(uid => resolveGlobalLikeId(uid)),
     }
   });
 
@@ -114,7 +109,10 @@ const SettingsPage = () => {
     )
   }
 
-  const allContentTypes = !isLoading && Object.values(allContentTypesData).filter(item => item.uid.includes('api::'));
+  const allContentTypes = !isLoading && Object.values(allContentTypesData).filter(({ uid }) => isContentTypeEligible(uid, {
+    allowedContentTypes: navigationConfigData?.allowedContentTypes,
+    restrictedContentTypes: navigationConfigData?.restrictedContentTypes,
+  }));
   const selectedContentTypes = navigationConfigData?.contentTypes.map(item => item.uid);
   const audienceFieldChecked = navigationConfigData?.additionalFields.includes(navigationItemAdditionalFields.AUDIENCE);
   const allowedLevels = navigationConfigData?.allowedLevels || 2;

--- a/admin/src/pages/SettingsPage/utils/functions.js
+++ b/admin/src/pages/SettingsPage/utils/functions.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { capitalize } = require("lodash");
+
+const UID_REGEX = /^(?<type>[a-z0-9-]+)\:{2}(?<api>[a-z0-9-]+)\.{1}(?<contentType>[a-z0-9-]+)$/i;
+
+const splitTypeUid = (uid = '') => {
+    return uid.split(UID_REGEX).filter((s) => s && s.length > 0);
+};
+
+module.exports = {
+    resolveGlobalLikeId(uid = '') {
+        const parse = (str) => str.split('-')
+            .map(_ => capitalize(_))
+            .join('');
+
+        const [type, scope, contentTypeName] = splitTypeUid(uid);
+        if (type === 'api') {
+            return parse(contentTypeName);
+        }
+        return `${parse(scope)}${parse(contentTypeName)}`;
+    },
+
+    isContentTypeEligible(uid = '', config = {}) {
+        const { allowedContentTypes = [], restrictedContentTypes = []} = config;
+        const isOneOfAllowedType = allowedContentTypes.filter(_ => uid.includes(_) || (uid === _)).length > 0;
+        const isNoneOfRestricted = restrictedContentTypes.filter(_ => uid.includes(_) || (uid === _)).length === 0;
+        return uid && isOneOfAllowedType && isNoneOfRestricted;
+    },
+}

--- a/server/services/utils/constant.js
+++ b/server/services/utils/constant.js
@@ -8,5 +8,14 @@ module.exports = {
 
     MODEL_TYPES: {
         CONTENT_TYPE: 'contentType'
-    }
+    },
+    ALLOWED_CONTENT_TYPES: [
+        'api::',
+        'plugin::'
+    ],
+    RESTRICTED_CONTENT_TYPES: [
+        'plugin::users-permissions',
+        'plugin::i18n.locale',
+        'plugin::navigation',
+    ],
 };

--- a/server/services/utils/functions.js
+++ b/server/services/utils/functions.js
@@ -13,7 +13,7 @@ const {
 
 const { type: itemType } = require('../../content-types/navigation-item/lifecycle');
 const { NavigationError } = require('../../../utils/NavigationError');
-const { TEMPLATE_DEFAULT } = require('./constant');
+const { TEMPLATE_DEFAULT, ALLOWED_CONTENT_TYPES, RESTRICTED_CONTENT_TYPES } = require('./constant');
 
 module.exports = ({ strapi }) => {
   return {
@@ -215,6 +215,12 @@ module.exports = ({ strapi }) => {
         return item.type === itemType.INTERNAL ? isRelatedDefinedAndPublished : true;
       }
       return (item.type !== itemType.INTERNAL) || relatedItem;
+    },
+
+    isContentTypeEligible(uid = '') {
+      const isOneOfAllowedType = ALLOWED_CONTENT_TYPES.filter(_ => uid.includes(_)).length > 0;
+      const isNoneOfRestricted = RESTRICTED_CONTENT_TYPES.filter(_ => uid.includes(_) || (uid === _)).length === 0;
+      return uid && isOneOfAllowedType && isNoneOfRestricted;
     },
   };
 }


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/184

## Summary

What does this PR do/solve? 

Provides support for all content types except restricted:

```js
[
        'plugin::users-permissions',
        'plugin::i18n.locale',
        'plugin::navigation',
]
```

## Test Plan

- run Strapi
- go to `Settings -> Navigation plugin -> Configuration`
- add one of typical content types + for example `File`, the built-in one
- play with navigation
