### PR TITLE
fix: graphql fails to render related

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Complete installation requirements are exact same as for Strapi itself and can b
 
 **Supported Strapi versions**:
 
-- Strapi v4.1.7 (recently tested)
+- Strapi v4.1.8 (recently tested)
 - Strapi v4.x
 
 > This plugin is designed for **Strapi v4** and is not working with v3.x. To get version for **Strapi v3** install version [v1.x](https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/tree/strapi-v3).
@@ -218,7 +218,7 @@ For any role different than **Super Admin**, to access the **Navigation panel** 
     "master": 1, // Navigation 'id'
     "createdAt": "2020-09-29T13:29:19.086Z",
     "updatedAt": "2020-09-29T13:29:19.128Z",
-    "related": [ /*<Content Type model >*/ ],
+    "related": {/*<Content Type model >*/ },
     "audience": []
 }
 ```
@@ -290,6 +290,10 @@ Plugin supports both **REST API** and **GraphQL API** exposed by Strapi.
 
 ### REST API
 
+> **Important!**
+> Version `v2.0.13` introduced breaking change!
+> All responses have changed their structure. Related field will now be of type ContentType instead of Array\<ContentType\>
+
 `GET <host>/api/navigation/render/<navigationIdOrSlug>?type=<type>`
 
 Return a rendered navigation structure depends on passed type (`tree`, `rfr` or nothing to render as `flat/raw`).
@@ -314,12 +318,12 @@ Return a rendered navigation structure depends on passed type (`tree`, `rfr` or 
         "master": 1,
         "created_at": "2020-09-29T13:29:19.086Z",
         "updated_at": "2020-09-29T13:29:19.128Z",
-        "related": [{
+        "related": {
             "__contentType": "Page",
             "id": 1,
             "title": "News",
             // ...
-        }]
+        }
     },
     // ...
 ]
@@ -512,7 +516,7 @@ query {
             "path": "/test-path/nested-one",
             "related": {
               "__typename": "Page",
-              "Title": "ghghghgh"
+              "Title": "Eg. Page title"
             }
           }
         ]

--- a/server/graphql/types/navigation-item.js
+++ b/server/graphql/types/navigation-item.js
@@ -10,7 +10,7 @@ module.exports = ({ nexus }) =>
 			t.nonNull.string("uiRouterKey")
 			t.nonNull.boolean("menuAttached")
 			t.nonNull.int("order")
-			t.int("parent")
+			t.field("parent", {type: "NavigationItem"})
 			t.int("master")
 			t.list.field("items", { type: 'NavigationItem' })
 			t.field("related", { type: 'NavigationRelated' })

--- a/server/graphql/types/navigation-item.js
+++ b/server/graphql/types/navigation-item.js
@@ -10,7 +10,7 @@ module.exports = ({ nexus }) =>
 			t.nonNull.string("uiRouterKey")
 			t.nonNull.boolean("menuAttached")
 			t.nonNull.int("order")
-			t.field("parent", {type: "NavigationItem"})
+			t.field("parent", { type: "NavigationItem" })
 			t.int("master")
 			t.list.field("items", { type: 'NavigationItem' })
 			t.field("related", { type: 'NavigationRelated' })

--- a/server/services/navigation.js
+++ b/server/services/navigation.js
@@ -474,10 +474,10 @@ module.exports = ({ strapi }) => {
                 ...item,
                 audience: item.audience?.map(_ => _.key),
                 title: utilsFunctions.composeItemTitle(item, contentTypesNameFields, contentTypes),
-                related: item.related?.map(({ localizations, ...item }) => item),
+                related: last(item.related?.map(({ localizations, ...item }) => item)),
                 items: null,
               }));
-            return isNil(rootPath) ? items : utilsFunctions.filterByPath(publishedItems, rootPath).items;
+            return isNil(rootPath) ? publishedItems : utilsFunctions.filterByPath(publishedItems, rootPath).items;
         }
       }
       throw new NotFoundError();


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/201
https://github.com/VirtusLab/strapi-plugin-navigation/issues/202

## Summary

Fixes problems with rendering `related` and `parent` fields. 

**! This PR introduces a breaking change: render API now returns related as a single element instead of an array !**

## Test Plan

How are you testing the work you're submitting?

- Test if response from `/api/navigation/render/` and `/api/navigation/renderChild/` returns correct response 
- Test graphql query :
```
{
  renderNavigation(navigationIdOrSlug: "1" ) {
   id
    parent {
      id
    }
    related{
      __typename
      ... on Post {
        title
      }
    }
  }
}
```
