### PR TITLE
fix: create default navigation while bootstrap if missing

### DIFF
--- a/server/i18n/navigationSetupStrategy.ts
+++ b/server/i18n/navigationSetupStrategy.ts
@@ -36,14 +36,7 @@ export const i18nNavigationSetupStrategy: INavigationSetupStrategy = async ({
 
     if (currentNavigations.length === 0) {
       currentNavigations = [
-        await createNavigation({
-          strapi,
-          payload: {
-            ...DEFAULT_NAVIGATION_ITEM,
-            localeCode: defaultLocale,
-          },
-          populate: DEFAULT_POPULATE,
-        }),
+        await createDefaultI18nNavigation({ strapi, defaultLocale }),
       ];
     }
 
@@ -122,6 +115,11 @@ export const i18nNavigationSetupStrategy: INavigationSetupStrategy = async ({
         },
       });
     }
+
+    const remainingNavigations = await getCurrentNavigations(strapi);
+    if (!remainingNavigations.length) {
+      await createDefaultI18nNavigation({ strapi, defaultLocale });
+    }
   }
 
   return getCurrentNavigations(strapi);
@@ -180,3 +178,15 @@ const deleteNavigations = ({
   strapi.query<Navigation>("plugin::navigation.navigation").deleteMany({
     where,
   });
+
+const createDefaultI18nNavigation = ({ strapi, defaultLocale }: {
+  strapi: IStrapi;
+  defaultLocale: string;
+}): Promise<Navigation> => createNavigation({
+  strapi,
+  payload: {
+    ...DEFAULT_NAVIGATION_ITEM,
+    localeCode: defaultLocale,
+  },
+  populate: DEFAULT_POPULATE,
+});

--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -69,8 +69,8 @@ const commonService: (context: StrapiContext) => ICommonService = ({ strapi }) =
                   const itemsCountOrBypass = isSingleTypeWithPublishFlow ?
                     await strapi.query<StrapiContentType<ToBeFixed>>(uid).count({
                       where: {
-                        publicationState: 'live',
-                      }
+                        published_at: { $notNull: true },
+                      },
                     }) :
                     true;
                   return returnType(itemsCountOrBypass !== 0);


### PR DESCRIPTION
## Ticket

N/A

## Summary

What does this PR do/solve? 

Covers the corner case for fresh instances of Strapi when:

1. `i18Plugin` is present 
2. There is no custom config set so `i18nEnabled` property is `false` by default
3. No default locale navigation is set

After fixing:
1. Navigation with default locale is going to be set only if no other instances are present in database
2. In addition fixed issue with `publicationState: true` which throws error for Single Types with flow enabled. Looking for `published_at: { $notNull: true }` now


## Test Plan

1. Clean DB + fresh Strapi instance
2. Run with empty config
3. See that default navigation is set anyway
