### PR TITLE
fix: CU-2hjq08q - related id in graphql, small refactors and alignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Plugin supports both **REST API** and **GraphQL API** exposed by Strapi.
 
 `GET <host>/api/navigation/render/<navigationIdOrSlug>?type=<type>`
 
-Return a rendered navigation structure depends on passed type (`tree`, `rfr` or nothing to render as `flat/raw`).
+Return a rendered navigation structure depends on passed type (`TREE`, `RFR` or nothing to render as `FLAT`).
 
 > The ID of navigation by default is `1`, if you've got defined multiple navigations you must work with their IDs or Slugs to fetch.
 
@@ -364,7 +364,7 @@ Return a rendered navigation structure depends on passed type (`tree`, `rfr` or 
 ]
 ```
 
-**Example URL**: `https://localhost:1337/api/navigation/render/1?type=tree`
+**Example URL**: `https://localhost:1337/api/navigation/render/1?type=TREE`
 
 **Example response body**
 
@@ -400,7 +400,7 @@ Return a rendered navigation structure depends on passed type (`tree`, `rfr` or 
 ]
 ```
 
-**Example URL**: `https://localhost:1337/api/navigation/render/1?type=rfr`
+**Example URL**: `https://localhost:1337/api/navigation/render/1?type=RFR`
 
 **Example response body**
 
@@ -485,7 +485,7 @@ Return a rendered navigation structure depends on passed type (`tree`, `rfr` or 
 
 ### GraphQL API
 
-Same as [**REST API**](#rest-api) returns a rendered navigation structure depends on passed type (`tree`, `rfr` or nothing to render as `flat/raw`).
+Same as [**REST API**](#rest-api) returns a rendered navigation structure depends on passed type (`TREE`, `RFR` or nothing to render as `FLAT`).
 
 **Example request**
 
@@ -500,21 +500,8 @@ query {
     title
     path
     related {
-      __typename
-
-      ... on Page {
-        Title
-      }
-
-      ... on WithFlowType {
-        Name
-      }
-    }
-    items {
       id
-      title
-      path
-      related {
+      attributes {
         __typename
 
         ... on Page {
@@ -523,6 +510,25 @@ query {
 
         ... on WithFlowType {
           Name
+        }
+      }
+    }
+    items {
+      id
+      title
+      path
+      related {
+        id
+        attributes {
+          __typename
+
+          ... on Page {
+            Title
+          }
+
+          ... on WithFlowType {
+            Name
+          }
         }
       }
     }
@@ -541,8 +547,11 @@ query {
         "title": "Test page",
         "path": "/test-path",
         "related": {
-          "__typename": "WithFlowType",
-          "Name": "Test"
+          "id": 3,
+          "attributes": {
+            "__typename": "WithFlowType",
+            "Name": "Test"
+          }
         },
         "items": [
           {
@@ -550,8 +559,11 @@ query {
             "title": "Nested",
             "path": "/test-path/nested-one",
             "related": {
-              "__typename": "Page",
-              "Title": "Eg. Page title"
+              "id": 1,
+              "attributes": {
+                  "__typename": "Page",
+                "Title": "Eg. Page title"
+              }
             }
           }
         ]
@@ -561,8 +573,11 @@ query {
         "title": "Another page",
         "path": "/another",
         "related": {
-          "__typename": "Page",
-          "Title": "dfdfdf"
+          "id": 2,
+          "attributes": {
+            "__typename": "Page",
+            "Title": "dfdfdf"
+          }
         },
         "items": []
       }

--- a/__mocks__/strapi.ts
+++ b/__mocks__/strapi.ts
@@ -113,29 +113,23 @@ const itemModelMock = {
 const pageModelMock = {
   findOne: async () => ({
     "id": 1,
-    "attributes": {
-      "title": "Page nr 1",
-      "createdAt": "2022-01-19T08:22:31.244Z",
-      "updatedAt": "2022-01-19T08:22:31.244Z",
-      "publishedAt": null
-    }
+    "title": "Page nr 1",
+    "createdAt": "2022-01-19T08:22:31.244Z",
+    "updatedAt": "2022-01-19T08:22:31.244Z",
+    "publishedAt": null
   }),
   findMany: async () => [{
     "id": 1,
-    "attributes": {
-      "title": "Page nr 1",
-      "createdAt": "2022-01-19T08:22:31.244Z",
-      "updatedAt": "2022-01-19T08:22:31.244Z",
-      "publishedAt": null
-    }
+    "title": "Page nr 1",
+    "createdAt": "2022-01-19T08:22:31.244Z",
+    "updatedAt": "2022-01-19T08:22:31.244Z",
+    "publishedAt": null
   }, {
     "id": 2,
-    "attributes": {
-      "title": "Page nr 2",
-      "createdAt": "2022-01-19T08:22:50.821Z",
-      "updatedAt": "2022-01-19T08:22:50.821Z",
-      "publishedAt": null
-    }
+    "title": "Page nr 2",
+    "createdAt": "2022-01-19T08:22:50.821Z",
+    "updatedAt": "2022-01-19T08:22:50.821Z",
+    "publishedAt": null
   }]
 
 };

--- a/admin/src/components/Item/index.js
+++ b/admin/src/components/Item/index.js
@@ -55,7 +55,7 @@ const Item = (props) => {
   const { contentTypes, contentTypesNameFields } = config;
   const isExternal = type === navigationItemType.EXTERNAL;
   const isWrapper = type === navigationItemType.WRAPPER;
-  const isHandledByPublishFlow = relatedRef && typeof relatedRef.publishedAt !== 'undefined';
+  const isHandledByPublishFlow = contentTypes.find(_ => _.uid === relatedRef.__collectionUid)?.draftAndPublish;
   const isPublished = isHandledByPublishFlow && relatedRef.publishedAt;
   const isNextMenuAllowedLevel = isNumber(allowedLevels) ? level < (allowedLevels - 1) : true;
   const isMenuAllowedLevel = isNumber(allowedLevels) ? level < allowedLevels : true;
@@ -175,7 +175,7 @@ const Item = (props) => {
                 </Flex>
                 {relatedItemLabel && (
                   <Flex justifyContent='center' alignItems='center'>
-                    <ItemCardBadge
+                    {isHandledByPublishFlow && (<ItemCardBadge
                       borderColor={`${relatedBadgeColor}200`}
                       backgroundColor={`${relatedBadgeColor}100`}
                       textColor={`${relatedBadgeColor}600`}
@@ -183,7 +183,7 @@ const Item = (props) => {
                       small
                     >
                       {getMessage({id: `components.navigationItem.badge.${isPublished ? 'published' : 'draft'}`})}
-                    </ItemCardBadge>
+                    </ItemCardBadge>)}
                     <Typography variant="omega" textColor='neutral600'>{relatedTypeLabel}&nbsp;/&nbsp;</Typography>
                     <Typography variant="omega" textColor='neutral800'>{relatedItemLabel}</Typography>
                       <Link

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "develop": "nodemon --exec \"npm run build:dev\""
   },
   "dependencies": {
-    "@strapi/utils": "^4.1.8",
+    "@strapi/utils": "^4.1.9",
     "bad-words": "^3.0.3",
     "uuid": "^8.3.0",
     "lodash": "^4.17.11",

--- a/server/graphql/queries/render-navigation-child.js
+++ b/server/graphql/queries/render-navigation-child.js
@@ -17,6 +17,7 @@ module.exports = ({ strapi, nexus }) => {
         childUIKey,
         type,
         menuOnly,
+        wrapRelated: true,
       });
     },
   };

--- a/server/graphql/queries/render-navigation.js
+++ b/server/graphql/queries/render-navigation.js
@@ -20,7 +20,14 @@ module.exports = ({ strapi, nexus }) => {
       obj,
       { navigationIdOrSlug: idOrSlug, type, menuOnly, path: rootPath, locale }
     ) {
-      return getPluginService('client').render({ idOrSlug, type, menuOnly, rootPath, locale })
+      return getPluginService('client').render({ 
+        idOrSlug,
+        type,
+        rootPath, 
+        locale, 
+        menuOnly,
+        wrapRelated: true 
+      })
     },
   };
 };

--- a/server/graphql/types/index.js
+++ b/server/graphql/types/index.js
@@ -1,6 +1,7 @@
 const typesFactories = [
+	require('./navigation-item-related'),
+	require('./navigation-item-related-data'),
 	require('./navigation-item'),
-	require('./navigation-related'),
 	require('./navigation-render-type'),
 	require('./navigation'),
 	require('./navigation-details'),

--- a/server/graphql/types/navigation-item-related-data.js
+++ b/server/graphql/types/navigation-item-related-data.js
@@ -1,0 +1,8 @@
+module.exports = ({ nexus }) =>
+	nexus.objectType({
+		name: "NavigationItemRelatedData",
+		definition(t) {
+			t.nonNull.int("id")
+			t.field("attributes", { type: 'NavigationItemRelated' })
+		}
+	});

--- a/server/graphql/types/navigation-item-related.js
+++ b/server/graphql/types/navigation-item-related.js
@@ -1,6 +1,6 @@
 module.exports = ({ strapi, nexus, config }) => {
 	const related = config.gql?.navigationItemRelated;
-	const name = "NavigationRelated";
+	const name = "NavigationItemRelated";
 
 	if (related?.length) {
 		return nexus.unionType({

--- a/server/graphql/types/navigation-item.js
+++ b/server/graphql/types/navigation-item.js
@@ -13,7 +13,7 @@ module.exports = ({ nexus }) =>
 			t.field("parent", { type: "NavigationItem" })
 			t.int("master")
 			t.list.field("items", { type: 'NavigationItem' })
-			t.field("related", { type: 'NavigationRelated' })
+			t.field("related", { type: 'NavigationItemRelatedData' })
 			t.list.string("audience")
 			// SQL
 			t.string("created_at")

--- a/server/graphql/types/navigation-render-type.js
+++ b/server/graphql/types/navigation-render-type.js
@@ -1,4 +1,6 @@
+const { RENDER_TYPES } = require("../../utils");
+
 module.exports = ({nexus}) => nexus.enumType({
   name: "NavigationRenderType",
-  members: ['FLAT','TREE','RFR'],
+  members: Object.values(RENDER_TYPES),
 });

--- a/server/i18n/navigationSetupStrategy.ts
+++ b/server/i18n/navigationSetupStrategy.ts
@@ -36,14 +36,7 @@ export const i18nNavigationSetupStrategy: INavigationSetupStrategy = async ({
 
     if (currentNavigations.length === 0) {
       currentNavigations = [
-        await createNavigation({
-          strapi,
-          payload: {
-            ...DEFAULT_NAVIGATION_ITEM,
-            localeCode: defaultLocale,
-          },
-          populate: DEFAULT_POPULATE,
-        }),
+        await createDefaultI18nNavigation({ strapi, defaultLocale }),
       ];
     }
 
@@ -122,6 +115,11 @@ export const i18nNavigationSetupStrategy: INavigationSetupStrategy = async ({
         },
       });
     }
+
+    const remainingNavigations = await getCurrentNavigations(strapi);
+    if (!remainingNavigations.length) {
+      await createDefaultI18nNavigation({ strapi, defaultLocale });
+    }
   }
 
   return getCurrentNavigations(strapi);
@@ -180,3 +178,15 @@ const deleteNavigations = ({
   strapi.query<Navigation>("plugin::navigation.navigation").deleteMany({
     where,
   });
+
+const createDefaultI18nNavigation = ({ strapi, defaultLocale }: {
+  strapi: IStrapi;
+  defaultLocale: string;
+}): Promise<Navigation> => createNavigation({
+  strapi,
+  payload: {
+    ...DEFAULT_NAVIGATION_ITEM,
+    localeCode: defaultLocale,
+  },
+  populate: DEFAULT_POPULATE,
+});

--- a/server/services/__tests__/service.test.ts
+++ b/server/services/__tests__/service.test.ts
@@ -2,7 +2,7 @@ import { IStrapi } from "strapi-typed";
 import { IClientService } from "../../../types";
 
 import setupStrapi from '../../../__mocks__/strapi';
-import { getPluginService } from "../../utils";
+import { getPluginService, RENDER_TYPES } from "../../utils";
 
 declare var strapi: IStrapi
 
@@ -47,7 +47,7 @@ describe('Navigation services', () => {
       const clientService = getPluginService<IClientService>('client');
       const result = await clientService.render({
         idOrSlug: 1,
-        type: 'tree'
+        type: RENDER_TYPES.TREE
       });
 
       expect(result).toBeDefined()
@@ -58,7 +58,7 @@ describe('Navigation services', () => {
       const clientService = getPluginService<IClientService>('client');
       const result = await clientService.render({
         idOrSlug: 1,
-        type: 'rfr'
+        type: RENDER_TYPES.RFR
       });
 
       expect(result).toBeDefined()
@@ -70,7 +70,7 @@ describe('Navigation services', () => {
       const clientService = getPluginService<IClientService>('client');
       const result = await clientService.render({
         idOrSlug: 1,
-        type: 'flat',
+        type: RENDER_TYPES.FLAT,
         menuOnly: true,
       });
 
@@ -82,7 +82,7 @@ describe('Navigation services', () => {
       const clientService = getPluginService<IClientService>('client');
       const result = await clientService.render({
         idOrSlug: 1,
-        type: 'flat',
+        type: RENDER_TYPES.FLAT,
         menuOnly: false,
         rootPath: '/home/side'
       });

--- a/server/services/__tests__/service.test.ts
+++ b/server/services/__tests__/service.test.ts
@@ -41,6 +41,18 @@ describe('Navigation services', () => {
 
       expect(result).toBeDefined()
       expect(result.length).toBe(2)
+      expect(result).toHaveProperty([0, 'related', 'id'], 1);
+      expect(result).toHaveProperty([0, 'related', 'title'], 'Page nr 1');
+    });
+
+    it('Can render branch in flat format for GraphQL', async () => {
+      const clientService = getPluginService<IClientService>('client');
+      const result = await clientService.render({ idOrSlug: 1, wrapRelated: true });
+
+      expect(result).toBeDefined();
+      expect(result.length).toBe(2);
+      expect(result).toHaveProperty([0, 'related', 'id'], 1);
+      expect(result).toHaveProperty([0, 'related', 'attributes', 'title'], 'Page nr 1');
     });
 
     it('Can render branch in tree format', async () => {
@@ -50,8 +62,26 @@ describe('Navigation services', () => {
         type: RENDER_TYPES.TREE
       });
 
-      expect(result).toBeDefined()
-      expect(result.length).toBeGreaterThan(0)
+      expect(result).toBeDefined();
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0].items).toBeDefined();
+      expect(result[0].items.length).toBeGreaterThan(0);
+    });
+
+    it('Can render branch in tree format for GraphQL', async () => {
+      const clientService = getPluginService<IClientService>('client');
+      const result = await clientService.render({
+        idOrSlug: 1,
+        type: RENDER_TYPES.TREE,
+        wrapRelated: true,
+      });
+
+      expect(result).toBeDefined();
+      expect(result.length).toBeGreaterThan(0);
+      expect(result).toHaveProperty([0, 'related', 'id'], 1);
+      expect(result).toHaveProperty([0, 'related', 'attributes', 'title'], 'Page nr 1');
+      expect(result).toHaveProperty([0, 'items', 0, 'related', 'id'], 2);
+      expect(result).toHaveProperty([0, 'items', 0, 'related', 'attributes', 'title'], 'Page nr 2');
     });
 
     it('Can render branch in rfr format', async () => {
@@ -64,6 +94,20 @@ describe('Navigation services', () => {
       expect(result).toBeDefined()
       expect(result.pages).toBeDefined()
       expect(result.nav).toBeDefined()
+    });
+
+    it('Can render branch in rfr format for GraphQL', async () => {
+      const clientService = getPluginService<IClientService>('client');
+      const result = await clientService.render({
+        idOrSlug: 1,
+        type: RENDER_TYPES.RFR,
+        wrapRelated: true,
+      });
+
+      expect(result).toBeDefined();
+      expect(result.pages).toBeDefined();
+      expect(result.nav).toBeDefined();
+      expect(result).toHaveProperty(['pages', 'home', 'related', 'id'], 1);
     });
 
     it('Can render only menu attached elements', async () => {

--- a/server/services/client.ts
+++ b/server/services/client.ts
@@ -331,16 +331,15 @@ const clientService: (context: StrapiContext) => IClientService = ({ strapi }) =
           }
           return filteredStructure;
         default:
-          const publishedItems = items
-            .filter(filterOutUnpublished)
-            .map((item: NavigationItemEntity<ContentTypeEntity>) => ({
-              ...item,
-              audience: item.audience?.map(_ => (_).key),
-              title: composeItemTitle(item, contentTypesNameFields, contentTypes) || '',
-              related: wrapContentType(item.related),//omit(item.related, 'localizations'),
-              items: null,
-            }));
-          return isNil(rootPath) ? items : filterByPath(publishedItems, rootPath).items;
+          const publishedItems = items.filter(filterOutUnpublished);
+          const result = isNil(rootPath) ? items : filterByPath(publishedItems, rootPath).items;
+          return result.map((item: NavigationItemEntity<ContentTypeEntity>) => ({
+            ...item,
+            audience: item.audience?.map(_ => (_).key),
+            title: composeItemTitle(item, contentTypesNameFields, contentTypes) || '',
+            related: wrapContentType(item.related),//omit(item.related, 'localizations'),
+            items: null,
+          }));
       }
     }
     throw new errors.NotFoundError();

--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -95,7 +95,7 @@ const commonService: (context: StrapiContext) => ICommonService = ({ strapi }) =
         const { uid, options, info, collectionName, modelName, apiName, plugin, kind, pluginOptions } = item;
         const { visible = true } = pluginOptions['content-manager'] || {};
         const { name, description } = info;
-        const { hidden, templateName } = options;
+        const { hidden, templateName, draftAndPublish } = options;
         const findRouteConfig = find(get(strapi.api, `[${modelName}].config.routes`, []),
           route => route.handler.includes('.find'));
         const findRoutePath = findRouteConfig && findRouteConfig.path.split('/')[1];
@@ -111,6 +111,7 @@ const commonService: (context: StrapiContext) => ICommonService = ({ strapi }) =
         return {
           uid,
           name: relationName,
+          draftAndPublish,
           isSingle,
           description,
           collectionName,

--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -69,8 +69,8 @@ const commonService: (context: StrapiContext) => ICommonService = ({ strapi }) =
                   const itemsCountOrBypass = isSingleTypeWithPublishFlow ?
                     await strapi.query<StrapiContentType<ToBeFixed>>(uid).count({
                       where: {
-                        publicationState: 'live',
-                      }
+                        published_at: { $notNull: true },
+                      },
                     }) :
                     true;
                   return returnType(itemsCountOrBypass !== 0);

--- a/server/utils/constant.ts
+++ b/server/utils/constant.ts
@@ -1,3 +1,4 @@
+import { RenderTypeOptions } from "../../types";
 import { I18N_DEFAULT_POPULATE } from "../i18n";
 
 export const TEMPLATE_DEFAULT = 'Generic' as const;
@@ -14,8 +15,8 @@ export const DEFAULT_NAVIGATION_ITEM = {
   slug: "main-navigation",
   visible: true,
 } as const;
-export enum RENDER_TYPES {
-  FLAT = 'FLAT',
-  TREE = 'TREE',
-  RFR = 'RFR'
-};
+export const RENDER_TYPES = {
+  FLAT: 'FLAT',
+  TREE: 'TREE',
+  RFR: 'RFR'
+} as RenderTypeOptions;

--- a/server/utils/constant.ts
+++ b/server/utils/constant.ts
@@ -14,3 +14,8 @@ export const DEFAULT_NAVIGATION_ITEM = {
   slug: "main-navigation",
   visible: true,
 } as const;
+export enum RENDER_TYPES {
+  FLAT = 'FLAT',
+  TREE = 'TREE',
+  RFR = 'RFR'
+};

--- a/types/services.ts
+++ b/types/services.ts
@@ -36,11 +36,11 @@ export interface ICommonService {
 }
 
 export interface IClientService {
-  render: (input: { idOrSlug: Id, type?: RenderType, menuOnly?: boolean, rootPath?: string } & I18nQueryParams) => Promise<ToBeFixed>,
-  renderChildren: (input: { idOrSlug: Id, childUIKey: string, type?: RenderType, menuOnly?: boolean } & I18nQueryParams) => Promise<ToBeFixed>,
+  render: (input: { idOrSlug: Id, type?: RenderType, menuOnly?: boolean, rootPath?: string, wrapRelated?: boolean } & I18nQueryParams) => Promise<ToBeFixed>,
+  renderChildren: (input: { idOrSlug: Id, childUIKey: string, type?: RenderType, menuOnly?: boolean, wrapRelated?: boolean } & I18nQueryParams) => Promise<ToBeFixed>,
   renderRFR: (items: NestedStructure<NavigationItem>[], parent: Id | null, parentNavItem: RFRNavItem | null, contentTypes: string[]) => ToBeFixed,
   renderRFRNav: (item: NavigationItem) => RFRNavItem,
   renderRFRPage: (item: NavigationItem & { related: ToBeFixed }, parent: Id | null) => ToBeFixed,
   renderTree(items: NavigationItemEntity<ContentTypeEntity>[], id: Id | null, field: keyof NavigationItemEntity, path: string | undefined, itemParser: ToBeFixed): ToBeFixed,
-  renderType: (input: { type: RenderType, criteria: ToBeFixed, itemCriteria: ToBeFixed, filter: ToBeFixed, rootPath: string | null } & I18nQueryParams) => ToBeFixed,
+  renderType: (input: { type: RenderType, criteria: ToBeFixed, itemCriteria: ToBeFixed, filter: ToBeFixed, rootPath: string | null, wrapRelated?: boolean } & I18nQueryParams) => ToBeFixed,
 }

--- a/types/utils.ts
+++ b/types/utils.ts
@@ -1,9 +1,10 @@
 import { isNumber } from "lodash";
 import { Id } from "strapi-typed";
+import { RENDER_TYPES } from "../server/utils";
 import { Navigation, NavigationItem, NavigationItemType, NestedStructure } from "./contentTypes"
 
 export type NavigationActionsCategories = 'toCreate' | 'toUpdate' | 'toRemove';
-export type RenderType = "flat" | "tree" | "rfr";
+export type RenderType = RENDER_TYPES.FLAT | RENDER_TYPES.TREE | RENDER_TYPES.RFR;
 export type StrapiRoutesTypes = 'admin' | 'content-api';
 export type ToBeFixed = any;
 export type DateString = string;

--- a/types/utils.ts
+++ b/types/utils.ts
@@ -1,10 +1,14 @@
 import { isNumber } from "lodash";
 import { Id } from "strapi-typed";
-import { RENDER_TYPES } from "../server/utils";
 import { Navigation, NavigationItem, NavigationItemType, NestedStructure } from "./contentTypes"
 
 export type NavigationActionsCategories = 'toCreate' | 'toUpdate' | 'toRemove';
-export type RenderType = RENDER_TYPES.FLAT | RENDER_TYPES.TREE | RENDER_TYPES.RFR;
+export type RenderTypeOptions = Readonly<{
+  FLAT: 'FLAT'
+  TREE: 'TREE'
+  RFR: 'RFR'
+}>;
+export type RenderType = keyof RenderTypeOptions;
 export type StrapiRoutesTypes = 'admin' | 'content-api';
 export type ToBeFixed = any;
 export type DateString = string;


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/188

## Summary

What does this PR do/solve? 

1. Provides coverage for `related.id` in GraphQL queries only like:
   ```gql
      related {
        id
        attributes {
          __typename

          ... on Page {
            Title
          }

          ... on WithFlowType {
            Name
          }
      }
    }
   ```
2. Fixes visibility of `draft` status for types which doesn't have publish flow enabled
3. Aligns the render type enums to `FLAT`, `TREE` and `RFR` for both REST and GQL API

## Test Plan

1. Run the app
2. Check your GQL navigation render query for any of content types
3. See that you're now able to get `id` and `attributes` properties
4. Do the same for REST for the same and see no difference in the payload comparing to previous version
