### PR TITLE
fix: i18n graphql query param as real i18n locale code

### DIFF
--- a/server/i18n/graphQLEnhancers.ts
+++ b/server/i18n/graphQLEnhancers.ts
@@ -1,5 +1,8 @@
 import { Nexus } from "../../types";
 
+// TODO: Find a way to get this key from the source plugin
+const LOCALE_SCALAR_TYPENAME = 'I18NLocaleCode';
+
 type RenderNavigationArgsEnhancer<T> = {
   previousArgs: T;
   nexus: Nexus;
@@ -10,5 +13,5 @@ export const addI18NRenderNavigationArgs = <T>({
   nexus,
 }: RenderNavigationArgsEnhancer<T>) => ({
   ...previousArgs,
-  locale: nexus.stringArg(),
+  locale: nexus.arg({ type: LOCALE_SCALAR_TYPENAME }),
 });


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/90

## Summary

What does this PR do/solve? 

- graphql locale param as `I18NLocaleCode` not a `String`

## Test Plan

How are you testing the work you're submitting?

- start strapi
- make GraphQL render navigation query with valid locale (it should work)
- make GraphQL render navigation query with invalid locale (like `"xd"` or simply locale not handled by your instance) (it should not work)
