### PR TITLE
fix: wrapper bugs and bootstrap graphql errors

### DIFF
--- a/admin/src/components/Item/index.js
+++ b/admin/src/components/Item/index.js
@@ -55,7 +55,7 @@ const Item = (props) => {
   const { contentTypes, contentTypesNameFields } = config;
   const isExternal = type === navigationItemType.EXTERNAL;
   const isWrapper = type === navigationItemType.WRAPPER;
-  const isHandledByPublishFlow = contentTypes.find(_ => _.uid === relatedRef.__collectionUid)?.draftAndPublish;
+  const isHandledByPublishFlow = contentTypes.find(_ => _.uid === relatedRef?.__collectionUid)?.draftAndPublish;
   const isPublished = isHandledByPublishFlow && relatedRef.publishedAt;
   const isNextMenuAllowedLevel = isNumber(allowedLevels) ? level < (allowedLevels - 1) : true;
   const isMenuAllowedLevel = isNumber(allowedLevels) ? level < allowedLevels : true;

--- a/server/graphql/queries/render-navigation.js
+++ b/server/graphql/queries/render-navigation.js
@@ -3,15 +3,17 @@ const { getPluginService } = require("../../utils");
 
 module.exports = ({ strapi, nexus }) => {
   const { nonNull, list, stringArg, booleanArg } = nexus;
-  const args = addI18NRenderNavigationArgs({
-    previousArgs: {
-      navigationIdOrSlug: nonNull(stringArg()),
-      type: "NavigationRenderType",
-      menuOnly: booleanArg(),
-      path: stringArg(),
-    },
+  const defaultArgs = {
+    navigationIdOrSlug: nonNull(stringArg()),
+    type: "NavigationRenderType",
+    menuOnly: booleanArg(),
+    path: stringArg(),
+  };
+  const hasI18nPlugin = !!strapi.plugin("i18n");
+  const args = hasI18nPlugin ? addI18NRenderNavigationArgs({
+    previousArgs: defaultArgs,
     nexus,
-  });
+  }) : defaultArgs;
 
   return {
     args,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/90

## Summary

What does this PR do/solve? 

- Fixes UI bugs with wrapper elements
- Fixes bootstrap errors when strapi doesn't have the I18n plugin installed

## Test Plan

How are you testing the work you're submitting?

- Create a strapi project without the I18n plugin 
- Start project
- Add and save wrapper element (and check if both render and graphql show this new element)
- Add the I18n plugin to the project
- Start the project again
- No errors should appear
