### PR TITLE
fix: editing related not working

### DIFF
--- a/admin/src/components/Item/index.js
+++ b/admin/src/components/Item/index.js
@@ -109,7 +109,7 @@ const Item = (props) => {
   const [{ isDragging }, drag, dragPreview] = useDrag({
     type: `${ItemTypes.NAVIGATION_ITEM}_${levelPath}`,
     item: () => {
-      return { ...item, relatedRef };
+      return item;
     },
     collect: monitor => ({
       isDragging: monitor.isDragging(),
@@ -139,20 +139,13 @@ const Item = (props) => {
               title={title}
               path={isExternal ? externalPath : absolutePath}
               icon={isExternal ? Earth : isWrapper ? Cog : LinkIcon}
-              onItemRemove={() => onItemRemove({
-                ...item,
-                relatedRef,
-              })}
+              onItemRemove={() => onItemRemove(item)}
               onItemEdit={() => onItemEdit({
                 ...item,
                 isMenuAllowedLevel,
                 isParentAttachedToMenu,
-                relatedRef,
               }, levelPath, isParentAttachedToMenu)}
-              onItemRestore={() => onItemRestore({
-                ...item,
-                relatedRef,
-              })}
+              onItemRestore={() => onItemRestore(item)}
               dragRef={refs.dragRef}
               removed={removed}
             />
@@ -162,7 +155,7 @@ const Item = (props) => {
             <CardBody style={{ padding: '8px' }}>
               <Flex style={{ width: '100%' }} direction="row" alignItems="center" justifyContent="space-between">
                 <Flex>
-                  {!isEmpty(item.items) && <CollapseButton toggle={() => onItemToggleCollapse({...item, relatedRef})} collapsed={collapsed} itemsCount={item.items.length}/>}
+                  {!isEmpty(item.items) && <CollapseButton toggle={() => onItemToggleCollapse(item)} collapsed={collapsed} itemsCount={item.items.length}/>}
                   <TextButton
                     disabled={removed}
                     startIcon={<Plus />}


### PR DESCRIPTION
## Ticket

When editing NavigationItem changing related items is not possible. 

## Summary

What does this PR do/solve? 

Fixes problem with parsing edited navigation item. 

## Test Plan

- Create strapi project
- Test adding and removing navigation items
- Test changing related to different content types and / or different content type entities
- Test editing other navigation item properties 
- No errors should appear 