### PR TITLE
fix: empty title in navigation item returns error

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/index.js
+++ b/admin/src/pages/View/components/NavigationItemForm/index.js
@@ -74,13 +74,27 @@ const NavigationItemForm = ({
     return null;
   };
 
+  const getDefaultTitle = useCallback((related, relatedType, isSingleSelected) => {
+    if (isSingleSelected) {
+      return contentTypes.find(_ => _.uid === relatedType)?.label
+    } else {
+      return extractRelatedItemLabel({
+        ...contentTypeEntities.find(_ => _.id === related),
+        __collectionUid: relatedType
+      }, contentTypesNameFields, { contentTypes });
+    }
+
+  }, [contentTypeEntities, contentTypesNameFields, contentTypes]);
+
   const sanitizePayload = (payload = {}) => {
     const { onItemClick, onItemLevelAddClick, related, relatedType, menuAttached, type, ...purePayload } = payload;
     const relatedId = related;
     const singleRelatedItem = isSingleSelected ? first(contentTypeEntities) : undefined;
     const relatedCollectionType = relatedType;
-    const title = payload.title;
-    
+    const title = !!payload.title?.trim()
+      ? payload.title
+      : getDefaultTitle(related, relatedType, isSingleSelected)
+
     return {
       ...purePayload,
       title,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/92

## Summary

What does this PR do/solve? 

Creates a method that fills an empty title with the name of the related entity

## Test Plan

How are you testing the work you're submitting?

- Create strapi project
- Try adding a navigation item with an empty title
- Try emptying the title of an existing item
- In both cases, empty titles should fill out with default values