### PR TITLE
Shortend Regex to support Application Protocols

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/utils/form.js
+++ b/admin/src/pages/View/components/NavigationItemForm/utils/form.js
@@ -29,7 +29,7 @@ export const form = {
           is: val => val === navigationItemType.EXTERNAL,
           then: yup.string()
             .required(translatedErrors.required)
-            .matches(/(#.*)|(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/, { 
+            .matches(/(#.*)|(\w+?:(\/\/)?\S+)/, { 
               excludeEmptyString: true,
               message: `${pluginId}.popup.item.form.externalPath.validation.type`,
             }),


### PR DESCRIPTION
The current Regex does not Support Protocols lile `mailto:test@test.test` or `tel:+49123456789`.

This regex now basically allows everything, but that's the only way to support all Application Protocols.

But there still is a Protocol required as you can see here: https://regexr.com/6m8mo

## Summary

What does this PR do/solve? 

> This new Regex check allows the usage of custom Application Protocols

## Test Plan

https://regexr.com/6m8mo
