### PR TITLE
feat: external path regex extensions [CU-2jtv9g6]

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/utils/form.js
+++ b/admin/src/pages/View/components/NavigationItemForm/utils/form.js
@@ -4,6 +4,13 @@ import { translatedErrors } from "@strapi/helper-plugin";
 import { navigationItemType } from "../../../utils/enums";
 import pluginId from "../../../../../pluginId";
 
+const externalPathRegexps = [
+  /^mailto:[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/,
+  /^tel:(\+\d{1,3})?[\s]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{3,4}$/,
+  /^#.*/,
+  /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/,  
+];
+
 export const form = {
   fieldsToDisable: [],
   fieldsToOmit: [],
@@ -29,10 +36,11 @@ export const form = {
           is: val => val === navigationItemType.EXTERNAL,
           then: yup.string()
             .required(translatedErrors.required)
-            .matches(/(#.*)|(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/, { 
-              excludeEmptyString: true,
-              message: `${pluginId}.popup.item.form.externalPath.validation.type`,
-            }),
+            .test(
+              `${pluginId}.popup.item.form.externalPath.validation.type`,
+              externalPath => 
+                externalPath ? externalPathRegexps.some(re => re.test(externalPath)) : true
+            ),
           otherwise: yup.string().notRequired(),
         }),
       menuAttached: yup.boolean(),


### PR DESCRIPTION
## Ticket

https://app.clickup.com/t/2jtv9g6

## Summary

- external path validation extension
- `mailto:` protocol
- `tel:` protocol

Valid telephone numbers

```
123-456-7890
(123) 456-7890
123 456 7890
123.456.7890
+91 (123) 456-7890
+911234567890

123-456-789
(123) 456-789
123 456 789
123.456.789
+91 (123) 456-789
+91123456789
```

## Test Plan

- add new external navigation item
- try setting external path as `mailto:test@test.com` or any other mail of your choice
- try setting external path as `mailto:<phone number>`
