### PR TITLE
fix: single type with multiple locale crashs tree and rfr api view

### DIFF
--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -76,7 +76,7 @@ const commonService: (context: StrapiContext) => ICommonService = ({ strapi }) =
                   return returnType(itemsCountOrBypass !== 0);
                 }
                 const isAvailable = await strapi.query<StrapiContentType<ToBeFixed>>(uid).count({});
-                return isAvailable === 1 ?
+                return isAvailable !== 0 ?
                   returnType(true) :
                   (viaSettingsPage ? returnType(false) : undefined);
               }


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/230

## Summary

What does this PR do/solve? 

Fixes a bug which prevented single types from multilang usage

## Test Plan

tests were made on our companies website which has a mixing of collection and single types. Also we have around 25 pages active and another 20 which are in draft and not linked to navigation.

1. Created navigations item with linking to single and collection types each with two languages
2. Create navigation item with linking to single and collection type with just one language