### PR TITLE
feat: populate with url

### DIFF
--- a/admin/src/pages/SettingsPage/index.tsx
+++ b/admin/src/pages/SettingsPage/index.tsx
@@ -54,8 +54,9 @@ import CustomFieldModal from './components/CustomFieldModal';
 import CustomFieldTable from './components/CustomFieldTable';
 import { HandleSetContentTypeExpanded, OnPopupClose, OnSave, PrepareNameFieldFor, PreparePayload, RestartReasons, RestartStatus, StrapiContentTypeSchema } from './types';
 
-const RESTART_NOT_REQUIRED: RestartStatus = { required: false }
-const RESTART_REQUIRED: RestartStatus = { required: true, reasons: [] }
+const RESTART_NOT_REQUIRED: RestartStatus = { required: false };
+const RESTART_REQUIRED: RestartStatus = { required: true, reasons: [] };
+const RELATION_ATTRIBUTE_TYPES = ['relation', 'media', 'component'];
 
 const SettingsPage = () => {
   const { lockApp, unlockApp } = useOverlayBlocker();
@@ -315,7 +316,7 @@ const SettingsPage = () => {
                                 if (!contentType) return;
                                 const { attributes, info: { displayName }, available, isSingle } = contentType;
                                 const stringAttributes = Object.keys(attributes).filter(_ => attributes[_].type === 'string');
-                                const relationAttributes = Object.keys(attributes).filter(_ => ['relation', 'media'].includes(attributes[_].type));
+                                const relationAttributes = Object.keys(attributes).filter(_ => RELATION_ATTRIBUTE_TYPES.includes(attributes[_].type));
                                 const key = `collectionSettings-${uid}`;
                                 return (<Accordion
                                   expanded={contentTypeExpanded === key}

--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -11,7 +11,7 @@ const clientControllers: IClientController = {
 
   async render(ctx) {
     const { params, query = {} } = ctx;
-    const { type, menu: menuOnly, path: rootPath, locale } = query;
+    const { type, menu: menuOnly, path: rootPath, locale, populate } = query;
     const { idOrSlug } = parseParams<StringMap<string>, { idOrSlug: Id }>(
       params
     );
@@ -22,6 +22,7 @@ const clientControllers: IClientController = {
         menuOnly,
         rootPath,
         locale,
+        populate
       });
     } catch (error: unknown) {
       if (error instanceof errors.NotFoundError) {

--- a/server/utils/functions.ts
+++ b/server/utils/functions.ts
@@ -13,6 +13,7 @@ import {
   uniqBy,
   zipWith,
 } from 'lodash';
+import { PopulateClause } from 'strapi-typed';
 import { Id, IStrapi, Primitive, StrapiContentType, StringMap, StrapiContentTypeFullSchema } from "strapi-typed";
 
 import {
@@ -29,6 +30,7 @@ import {
   NestedPath,
   NestedStructure,
   PluginConfigNameFields,
+  PopulateQueryParam,
   ToBeFixed,
 } from "../../types";
 import { NavigationError } from '../../utils/NavigationError';
@@ -347,3 +349,13 @@ export const validateAdditionalFields = (additionalFields: NavigationItemAdditio
     throw new Error(`Name of custom field cannot be one of: ${forbiddenNames.join(', ')}`);
   }
 };
+
+export const parsePopulateQuery = (populate: PopulateQueryParam): PopulateClause => {
+  if (populate === "*") {
+    return true;
+  } else if (typeof populate === "string") {
+    return [populate];
+  } else {
+    return populate;
+  }
+}

--- a/types/services.ts
+++ b/types/services.ts
@@ -2,7 +2,7 @@ import { Id, StrapiContentType, StrapiEvents, StrapiStore, StringMap } from "str
 import { NavigationPluginConfig } from "./config";
 import { Navigation, NavigationItem, NavigationItemCustomField, NavigationItemEntity, NavigationItemInput, NestedStructure, NotVoid, RelatedRef, RelatedRefBase } from "./contentTypes";
 import { I18nQueryParams } from "./i18n";
-import { AuditLogContext, ContentTypeEntity, NavigationActions, NavigationActionsPerItem, RenderType, RFRNavItem, ToBeFixed } from "./utils";
+import { AuditLogContext, ContentTypeEntity, NavigationActions, NavigationActionsPerItem, PopulateQueryParam, RenderType, RFRNavItem, ToBeFixed } from "./utils";
 
 export type NavigationServiceName = "common" | "admin" | "client"
 export type NavigationService = ICommonService | IAdminService | IClientService
@@ -17,7 +17,7 @@ export interface IAdminService {
   restart: () => Promise<void>,
   restoreConfig: () => Promise<void>,
   updateConfig: (newConfig: NavigationPluginConfig) => Promise<void>,
-  fillFromOtherLocale(payload: { source: number; target: number; auditLog: AuditLogContext}): Promise<Navigation>;
+  fillFromOtherLocale(payload: { source: number; target: number; auditLog: AuditLogContext }): Promise<Navigation>;
   readNavigationItemFromLocale(payload: { source: number; target: number; path: string; }): Promise<
     Partial<
       Pick<NotVoid<Navigation['items']>[number], 'path' | 'related' | 'type' | 'uiRouterKey' | 'title' | 'externalPath'>
@@ -34,7 +34,7 @@ export interface ICommonService {
   getContentTypeItems: (uid: string, query: StringMap<string>) => Promise<ContentTypeEntity[]>,
   getIdsRelated: (relatedItems: RelatedRefBase[] | RelatedRef[] | null, master: number) => Promise<Id[] | void>,
   getPluginStore: () => Promise<StrapiStore>,
-  getRelatedItems: (entityItems: NavigationItemEntity[]) => Promise<NavigationItemEntity<ContentTypeEntity>[]>,
+  getRelatedItems: (entityItems: NavigationItemEntity[], populate?: PopulateQueryParam) => Promise<NavigationItemEntity<ContentTypeEntity>[]>,
   pruneCustomFields: (removedFields: NavigationItemCustomField[]) => Promise<void>,
   removeBranch: (items: NestedStructure<NavigationItem>[], operations: NavigationActions) => ToBeFixed,
   removeRelated: (relatedItems: RelatedRef[], master: number) => ToBeFixed
@@ -43,11 +43,11 @@ export interface ICommonService {
 }
 
 export interface IClientService {
-  render: (input: { idOrSlug: Id, type?: RenderType, menuOnly?: boolean, rootPath?: string, wrapRelated?: boolean } & I18nQueryParams) => Promise<ToBeFixed>,
+  render: (input: { idOrSlug: Id, type?: RenderType, menuOnly?: boolean, rootPath?: string, wrapRelated?: boolean, populate?: PopulateQueryParam } & I18nQueryParams) => Promise<ToBeFixed>,
   renderChildren: (input: { idOrSlug: Id, childUIKey: string, type?: RenderType, menuOnly?: boolean, wrapRelated?: boolean } & I18nQueryParams) => Promise<ToBeFixed>,
-  renderRFR: (input: { items: NestedStructure<NavigationItem>[], parent?: Id | null, parentNavItem?: RFRNavItem | null, contentTypes: string[], enabledCustomFieldsNames: string[]}) => ToBeFixed,
+  renderRFR: (input: { items: NestedStructure<NavigationItem>[], parent?: Id | null, parentNavItem?: RFRNavItem | null, contentTypes: string[], enabledCustomFieldsNames: string[] }) => ToBeFixed,
   renderRFRNav: (item: NavigationItem) => RFRNavItem,
   renderRFRPage: (item: NavigationItem & { related: ToBeFixed }, parent: Id | null, enabledCustomFieldsNames: string[]) => ToBeFixed,
   renderTree(items: NavigationItemEntity<ContentTypeEntity>[], id: Id | null, field: keyof NavigationItemEntity, path: string | undefined, itemParser: ToBeFixed): ToBeFixed,
-  renderType: (input: { type: RenderType, criteria: ToBeFixed, itemCriteria: ToBeFixed, filter: ToBeFixed, rootPath: string | null, wrapRelated?: boolean } & I18nQueryParams) => ToBeFixed,
+  renderType: (input: { type: RenderType, criteria: ToBeFixed, itemCriteria: ToBeFixed, filter: ToBeFixed, rootPath: string | null, wrapRelated?: boolean, populate?: PopulateQueryParam } & I18nQueryParams) => ToBeFixed,
 }

--- a/types/utils.ts
+++ b/types/utils.ts
@@ -1,4 +1,4 @@
-import { Id } from "strapi-typed";
+import { Id, PopulateClause } from "strapi-typed";
 import { Navigation, NavigationItem, NavigationItemType, NestedStructure } from "./contentTypes"
 
 export type Effect<T> = (value: T) => void
@@ -13,6 +13,7 @@ export type RenderType = keyof RenderTypeOptions;
 export type StrapiRoutesTypes = 'admin' | 'content-api';
 export type ToBeFixed = any;
 export type DateString = string;
+export type PopulateQueryParam = string | PopulateClause;
 
 export type NavigationActions = {
   create?: boolean;


### PR DESCRIPTION
## Ticket

Based on:
https://github.com/VirtusLab/strapi-plugin-navigation/issues/239

## Summary

What does this PR do/solve? 

> Adds possibility to populate related items with URL params. This option overrides populate options configured through the settings page.

## Test Plan

How are you testing the work you're submitting?

- Create project
- Test render endpoints in all types
- Adding populate like in [strapi docs](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/populating-fields.html#population) should populate related items fields (like: media, components, localizations, all other relations)
