### PR TITLE
fix: external navigation item path regexes

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/utils/form.ts
+++ b/admin/src/pages/View/components/NavigationItemForm/utils/form.ts
@@ -8,8 +8,8 @@ import { RawFormPayload } from "../types";
 import pluginId from "../../../../../pluginId";
 
 const externalPathRegexps = [
-  /^mailto:[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/,
-  /^tel:(\+\d{1,3})?[\s]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{3,4}$/,
+  /^mailto:[\w-\.]+@([\w-]+\.)+[\w-]{2,}$/,
+  /^tel:(\+\d{1,3})?[\s]?(\(?\d{2,3}\)?)?[\s.-]?(\d{3})?[\s.-]?\d{3,4}$/,
   /^#.*/,
   /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/,
 ];


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/254

## Summary

External navigation items path regexes updates
- shorter telefon numbers are allowed
- longer domain names are allowed

## Test Plan

- addresses like `my@example.online` are allowed
- telephone numbers like `+49121212`, `tel:121212` are allowed