### PR TITLE
fix: wrong relation between navigation and items

### DIFF
--- a/server/content-types/navigation-item/schema.ts
+++ b/server/content-types/navigation-item/schema.ts
@@ -88,7 +88,8 @@ export default {
       type: "relation",
       relation: "manyToOne",
       target: "plugin::navigation.navigation",
-      configurable: false
+      configurable: false,
+      inversedBy: "items",
     },
     audience: {
       type: "relation",

--- a/server/content-types/navigation/schema.ts
+++ b/server/content-types/navigation/schema.ts
@@ -39,7 +39,8 @@ export default {
       type: "relation",
       relation: "oneToMany",
       target: "plugin::navigation.navigation-item",
-      configurable: false
+      configurable: false,
+      mappedBy: "master"
     },
     localizations: {
       type: "relation",


### PR DESCRIPTION
## Ticket

NA

## Summary

What does this PR do/solve? 

> Fixes the relations between navigation and navigation items. Before this relation created 2 tables with links, but only saved data to one of them. Now this relation uses `mappedBy` and `inversedBy` params to avoid mentioned behavior. 

## Test Plan

I've tested this change on two different cases. 
- Clean install, without data
- Migration from the latest install, with data.

No data should disappear. The plugin should work the same on both versions. No output should change in render functions. The only difference should be the lack of `navigations_items_links` table. 
