### PR TITLE
fix: default path for single types

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/index.tsx
+++ b/admin/src/pages/View/components/NavigationItemForm/index.tsx
@@ -103,7 +103,11 @@ const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
 
   const generatePreviewPath = () => {
     if (!isExternal) {
-      const value = `${data.levelPath !== '/' ? `${data.levelPath}` : ''}/${formik.values.path !== '/' ? formik.values.path || '' : ''}`;
+      const itemPath = isEmpty(formik.values.path) || formik.values.path === '/'
+        ? getDefaultPath()
+        : formik.values.path || "";
+      
+      const value = `${data.levelPath !== '/' ? `${data.levelPath}` : ''}/${itemPath}`;
       return {
         id: getTradId('popup.item.form.type.external.description'),
         defaultMessage: '',
@@ -171,11 +175,14 @@ const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
 
     const pathDefaultFields = get(config, ["pathDefaultFields", relatedTypeSelectValue], []);
     if (isEmpty(formik.values.path) && !isEmpty(pathDefaultFields)) {
-      const selectedEntity = contentTypeEntities.find(i => i.id === relatedSelectValue);
+      const selectedEntity = isSingleSelected
+        ? first(contentTypeEntities)
+        : contentTypeEntities.find(i => i.id === relatedSelectValue);
+      
       const pathDefaultValues = pathDefaultFields
         .map((field) => get(selectedEntity, field, ""))
         .filter(value => !isNil(value) && String(value).match(/^\S+$/));
-      return String(first(pathDefaultValues));
+      return String(first(pathDefaultValues) || "");
     }
     return "";
   }, [relatedTypeSelectValue, formik, config]);


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/277

## Summary

> Fixed issue with default path value when single type is selected
> Added a better visual preview of the path that will be set after submitting a new navigation item. 

## Test Plan

- Create a single content type and add a default path field in settings for this content type
- Try adding a new navigation item without the path field filled
- Try providing the wrong field on the settings page for single content type ( for example field containing spaces in its values )
- Adding a navigation item without a path field filled and with the wrong default field should result in an error in the navigation item form 
