### PR TITLE
fix: error by parent not menu attached but with children that is while disabled cascade menu attached

### DIFF
--- a/server/services/client.ts
+++ b/server/services/client.ts
@@ -362,7 +362,7 @@ const clientService: (context: StrapiContext) => IClientService = ({ strapi }) =
             const { order, parent } = item;
 
             const nestedOrders = parent
-              ? getNestedOrders(parent.id, cache).concat(order)
+              ? !menuOnly ? getNestedOrders(parent.id, cache).concat(order) : [order]
               : [order];
 
             cache.set(id, nestedOrders);

--- a/server/services/client.ts
+++ b/server/services/client.ts
@@ -25,7 +25,7 @@ const clientService: (context: StrapiContext) => IClientService = ({ strapi }) =
     const criteria = findById ? { id: idOrSlug } : { slug: idOrSlug };
     const itemCriteria = menuOnly ? { menuAttached: true } : {};
     return await clientService.renderType({
-      type, criteria, itemCriteria, filter: null, rootPath, wrapRelated, locale, populate
+      type, criteria, itemCriteria, filter: null, rootPath, wrapRelated, locale, populate, menuOnly,
     });
   },
 
@@ -233,6 +233,7 @@ const clientService: (context: StrapiContext) => IClientService = ({ strapi }) =
     wrapRelated = false,
     locale,
     populate,
+    menuOnly,
   }) {
     const clientService = getPluginService<IClientService>('client');
     const adminService = getPluginService<IAdminService>('admin');

--- a/types/services.ts
+++ b/types/services.ts
@@ -49,5 +49,5 @@ export interface IClientService {
   renderRFRNav: (item: NavigationItem) => RFRNavItem,
   renderRFRPage: (item: NavigationItem & { related: ToBeFixed }, parent: Id | null, enabledCustomFieldsNames: string[]) => ToBeFixed,
   renderTree(items: NavigationItemEntity<ContentTypeEntity>[], id: Id | null, field: keyof NavigationItemEntity, path: string | undefined, itemParser: ToBeFixed): ToBeFixed,
-  renderType: (input: { type: RenderType, criteria: ToBeFixed, itemCriteria: ToBeFixed, filter: ToBeFixed, rootPath: string | null, wrapRelated?: boolean, populate?: PopulateQueryParam } & I18nQueryParams) => ToBeFixed,
+  renderType: (input: { type: RenderType, criteria: ToBeFixed, itemCriteria: ToBeFixed, filter: ToBeFixed, rootPath: string | null, wrapRelated?: boolean, populate?: PopulateQueryParam, menuOnly?: boolean } & I18nQueryParams) => ToBeFixed,
 }


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/285

## Summary

> What does this PR do/solve? 

Fixes an error occuring by parent item which is menu attached and has children. It only happens when the plugin option "Cascade menu attached" is enabled.

## Test Plan

> How are you testing the work you're submitting?

I created a multi-level navigation for testing purposes. I compared the `default`, `tree` and `rfr` renders with before and after the change from this request with each other. Everything seems to work and only the bug is fixed from my end.

Please consider making an additional test on your own, since it lays on such a crucial place where a lot comes together. I did not reverse engineer all the code in the file, only bug related areas. I can't really know what side effects could occure.
