### PR TITLE
Chore/version 2 2 3

### DIFF
--- a/admin/src/pages/View/index.js
+++ b/admin/src/pages/View/index.js
@@ -83,6 +83,7 @@ const View = () => {
   const [searchValue, setSearchValue] = useState('');
   const [structureChanged, setStructureChanged] = useState(false);
   const isSearchEmpty = isEmpty(searchValue);
+  const normalisedSearchValue = (searchValue || '').toLowerCase();
 
   const structureHasErrors = !validateNavigationStructure((changedActiveNavigation || {}).items);
   

--- a/admin/src/pages/View/index.js
+++ b/admin/src/pages/View/index.js
@@ -149,7 +149,7 @@ const View = () => {
     else
       return [...subItems, ...acc];
   }, []);
-  const filteredList = !isSearchEmpty ? filteredListFactory(changedActiveNavigation.items, (item) => (item?.title || '').toLowerCase().includes(searchValue.toLowerCase())) : [];
+  const filteredList = !isSearchEmpty ? filteredListFactory(changedActiveNavigation.items, (item) => (item?.title || '').toLowerCase().includes(normalisedSearchValue)) : [];
 
   const changeCollapseItemDeep = (item, isCollapsed) => {
     if (item.collapsed !== isCollapsed) {

--- a/admin/src/pages/View/index.js
+++ b/admin/src/pages/View/index.js
@@ -149,7 +149,7 @@ const View = () => {
     else
       return [...subItems, ...acc];
   }, []);
-  const filteredList = !isSearchEmpty ? filteredListFactory(changedActiveNavigation.items, (item) => item?.title.includes(searchValue)) : [];
+  const filteredList = !isSearchEmpty ? filteredListFactory(changedActiveNavigation.items, (item) => (item?.title || '').toLowerCase().includes(searchValue.toLowerCase())) : [];
 
   const changeCollapseItemDeep = (item, isCollapsed) => {
     if (item.collapsed !== isCollapsed) {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     }
   ],
   "engines": {
-    "node": ">=14.19.3 <=17.x.x",
+    "node": ">=14.19.3 <=18.x.x",
     "npm": ">=7.x.x"
   },
   "nodemonConfig": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@sindresorhus/slugify": "1.1.0",
-    "@strapi/utils": "^4.3.8",
+    "@strapi/utils": "^4.5.4",
     "lodash": "^4.17.11",
     "pluralize": "^8.0.0",
     "react": "^16.9.0",
@@ -80,7 +80,7 @@
     }
   ],
   "engines": {
-    "node": ">=14.19.3 <=18.x.x",
+    "node": ">=14.19.1 <=18.x.x",
     "npm": ">=7.x.x"
   },
   "nodemonConfig": {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/292
https://github.com/VirtusLab/strapi-plugin-navigation/issues/276

## Summary

What does this PR do/solve? 

Fixes `nodejs` version in `package.json` as well as introduces case insensitive search.

## Test Plan

How are you testing the work you're submitting?

1. Run on `node 18`
2. Try to search by case sensitive and insensitive way, see results
