### PR TITLE
fix: long path handling on menu ui

### DIFF
--- a/admin/src/components/Item/ItemCardHeader/index.tsx
+++ b/admin/src/components/Item/ItemCardHeader/index.tsx
@@ -27,6 +27,7 @@ interface IProps {
 }
 
 const wrapperStyle = { zIndex: 2 };
+const pathWrapperStyle = { maxWidth: "425px" };
 
 const ItemCardHeader: React.FC<IProps> = ({ title, path, icon, removed, onItemRemove, onItemEdit, onItemRestore, dragRef }) => (
   <Wrapper>
@@ -35,10 +36,12 @@ const ItemCardHeader: React.FC<IProps> = ({ title, path, icon, removed, onItemRe
       <Typography variant="omega" fontWeight="bold">
         {title}
       </Typography>
-      <Typography variant="omega" fontWeight="bold" textColor='neutral500'>
+      <Typography variant="omega" fontWeight="bold" textColor='neutral500' ellipsis style={pathWrapperStyle}>
         {path}
       </Typography>
-      <Icon as={icon} />
+      <Flex>
+        <Icon as={icon} />
+      </Flex>
     </Flex>
     <Flex alignItems="center" style={wrapperStyle}>
       {removed &&


### PR DESCRIPTION
## Ticket

[https://github.com/VirtusLab/strapi-plugin-navigation/issues/-<your-ticket-#>](https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/299)

## Summary

What does this PR do/solve? 

Handling really long paths by creating max width container.

![](https://user-images.githubusercontent.com/13495487/213454572-7f2960b9-44a6-4881-b05f-faae1fec0e1d.png)

## Test Plan

How are you testing the work you're submitting?
