### PR TITLE
fix(server): default pluginOptions to empty object

### DIFF
--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -93,7 +93,7 @@ const commonService: (context: StrapiContext) => ICommonService = ({ strapi }) =
         const { key, available } = value;
         const item = strapi.contentTypes[key];
         const relatedField = (item.associations || []).find((_: ToBeFixed) => _.model === 'navigationitem');
-        const { uid, options, info, collectionName, modelName, apiName, plugin, kind, pluginOptions } = item;
+        const { uid, options, info, collectionName, modelName, apiName, plugin, kind, pluginOptions = {} } = item;
         const { visible = true } = pluginOptions['content-manager'] || {};
         const { name, description } = info;
         const { hidden, templateName, draftAndPublish } = options;


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/309

## Summary

Not all Content-Types have the `pluginOptions`. Defaulting to an empty object, otherwise, the plugin fails when it loads

<img width="899" alt="image" src="https://user-images.githubusercontent.com/1881266/234211437-8c701a55-7ab7-4446-9d80-a962417785fd.png">


