### PR TITLE
fix: bad strict comparision string/number

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/index.tsx
+++ b/admin/src/pages/View/components/NavigationItemForm/index.tsx
@@ -190,8 +190,7 @@ const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
     if (isEmpty(formik.values.path) && !isEmpty(pathDefaultFields)) {
       const selectedEntity = isSingleSelected
         ? first(contentTypeEntities)
-        : contentTypeEntities.find(i => i.id === relatedSelectValue);
-      
+        : contentTypeEntities.find(i => String(i.id) === relatedSelectValue);
       const pathDefaultValues = pathDefaultFields
         .map((field) => get(selectedEntity, field, ""))
         .filter(value => !isNil(value) && String(value).match(/^\S+$/));


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/341

## Summary

> What does this PR do/solve?

This PR fix the problem of entity not being selected correctly in the item modal because formik use a string named "related" but compared of Number "id"

## Test Plan

> How are you testing the work you're submitting?

I create a menu item in Strapi 4.10 and if i select an entity with linked "path default fields", but not linked with selected entity in modal (before fix), now correctly selected.