### PR TITLE
Fix: bad strict comparison String/Number

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/index.tsx
+++ b/admin/src/pages/View/components/NavigationItemForm/index.tsx
@@ -139,7 +139,7 @@ const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
         }
       } else {
         selectedEntity = {
-          ...contentTypeEntities.find(_ => _.id === related),
+          ...contentTypeEntities.find(_ => String(_.id) === related),
           __collectionUid: relatedType
         };
       }


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/350

## Summary

What does this PR do/solve? 

This PR fix the problem of entity not being selected correctly in the item modal because formik use a string named "related" but compared of Number "id". 

I believe the same problem may still occur in other places, there was almost identical PR merged recently: https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/pull/344. 

Maybe it would be a good idea to parse the content type item `id` to `String` as soon as it is fetched. That would require adding 
```
contentTypeItems: (isArray ? contentTypeItems : [contentTypeItems]).map(item => ({
        ...item,
        id: String(item.id), // add parsing ID to string
        __collectionUid: get(fetchedContentType, 'collectionUid', modelUID),
      })),
```
in https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/blob/master/admin/src/pages/DataManagerProvider/index.js#L219.

I don't know the plugin code well enough, and I'm so I decided to add just the "local" fix for now.

## Test Plan

1. Create collection type `Page` with field `title` of type `Text`
2. Set `title` in `Name fields` in navigation plugin settings
3. Add new menu item by selecting existing `Page` entity
4. Menu item is created with the title of `Page` entity (this was not the case before the fix, nothing was happening when you click `Save`)
