### PR TITLE
fix: deleted related content types

### DIFF
--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -267,14 +267,22 @@ const commonService: (context: StrapiContext) => ICommonService = ({ strapi }) =
         await Promise.all(
           Object.entries(groupedItems)
             .map(async ([model, related]) => {
-              const relationData = await strapi
-                .query<StrapiContentType<ToBeFixed>>(model)
-                .findMany({
-                  where: {
-                    id: { $in: map(related, 'related_id') },
-                  },
-                  populate: isNil(populate) ? config.contentTypesPopulate[model] || [] : parsePopulateQuery(populate)
-                });
+              let relationData = [];
+
+              try {
+                relationData = await strapi
+                  .query<StrapiContentType<ToBeFixed>>(model)
+                  .findMany({
+                    where: {
+                      id: { $in: map(related, 'related_id') },
+                    },
+                    populate: isNil(populate) ? config.contentTypesPopulate[model] || [] : parsePopulateQuery(populate)
+                  });
+              } catch (e: unknown) {
+                console.log("Related content type was removed. See details below.");
+                console.error(e);
+              }
+
               return relationData
                 .flatMap(_ =>
                   Object.assign(

--- a/server/utils/functions.ts
+++ b/server/utils/functions.ts
@@ -1,4 +1,5 @@
 import {
+  capitalize,
   find,
   first,
   flatten,
@@ -37,6 +38,8 @@ import {
 import { NavigationError } from '../../utils/NavigationError';
 import { TEMPLATE_DEFAULT, ALLOWED_CONTENT_TYPES, RESTRICTED_CONTENT_TYPES } from './constant';
 declare var strapi: IStrapi;
+
+const UID_REGEX = /^(?<type>[a-z0-9-]+)\:{2}(?<api>[a-z0-9-]+)\.{1}(?<contentType>[a-z0-9-]+)$/i;
 
 export const getPluginService = <T extends NavigationService>(name: NavigationServiceName): T =>
   strapi.plugin("navigation").service(name);
@@ -375,4 +378,21 @@ export const purgeSensitiveData = (data: any = {}) => {
       ...prev,
       [curr]: data[curr],
     }), {});
+};
+
+export const resolveGlobalLikeId = (uid = '') =>  {
+    const parse = (str: string) => str.split('-')
+        .map(_ => capitalize(_))
+        .join('');
+
+    const [type, scope, contentTypeName] = splitTypeUid(uid);
+
+    if (type === 'api') {
+        return parse(contentTypeName);
+    }
+    return `${parse(scope)}${parse(contentTypeName)}`;
+};
+
+const splitTypeUid = (uid = '') => {
+    return uid.split(UID_REGEX).filter((s) => s && s.length > 0);
 };


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/355

## Summary

Handling of situation when connected to navigation content type is removed from the system.

- settings updated to remove non-existent content types
- when navigation is rendered related items of non-existent content types ignored. error message displayed on such event

## Test Plan

- start an app
- create content type
- add item of said content type
- add navigation or navigation item related to newly created content type
- remove create content type
- server should be able to restart
- navigation is updated with clean-up of settings of non-existent content type
- navigation is renderable