### PR TITLE
fix: duplicated navigation items error message

### DIFF
--- a/admin/src/pages/DataManagerProvider/index.js
+++ b/admin/src/pages/DataManagerProvider/index.js
@@ -332,27 +332,36 @@ const DataManagerProvider = ({ children }) => {
          message: getTrad('notification.navigation.submit'),
        });
      } catch (err) {
-       dispatch({
-         type: SUBMIT_NAVIGATION_ERROR,
-         error: err.response.payload.data
-       });
-       console.error({ err: err.response });
+        dispatch({
+          type: SUBMIT_NAVIGATION_ERROR,
+          error: err.response.payload.data
+        });
 
-       if (err.response.payload.data && err.response.payload.data.errorTitles) {
-         return toggleNotification({
-           type: 'warning',
-           message: {
-             id: formatMessage(
-               getTrad('notification.navigation.error'),
-               { ...err.response.payload.data, errorTitles: err.response.payload.data.errorTitles.join(' and ') },
-             )
+        if (
+          err.response.payload.error &&
+          err.response.payload.error.details &&
+          err.response.payload.error.details.errorTitles
+        ) {
+          return toggleNotification({
+            type: 'warning',
+            message: {
+              id: formatMessage(
+                getTrad('notification.navigation.error'),
+                {
+                  ...err.response.payload.error.details,
+                  errorTitles: err.response.payload.error.details.errorTitles
+                    .map(title => `"${title}"`)
+                    .join(", ")
+                },
+              )
            },
          });
-       }
-       toggleNotification({
-         type: 'warning',
-         message: getTrad('notification.error'),
-       });
+        }
+
+        toggleNotification({
+            type: 'warning',
+            message: getTrad('notification.error'),
+        });
      }
   };
 

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -77,7 +77,7 @@
   "popup.navigation.manage.navigation.visible": "visible",
   "popup.navigation.manage.navigation.hidden": "hidden",
   "notification.navigation.submit": "Navigation changes has been saved",
-  "notification.navigation.error": "Duplicate path: { path } in parent: { parentTitle } for { errorTitles } items",
+  "notification.navigation.error": "Duplicate path: \"{ path }\" in parent: \"{ parentTitle }\" for { errorTitles } items",
   "notification.navigation.item.relation": "Entity relation does not exist!",
   "notification.navigation.item.relation.status.draft": "draft",
   "notification.navigation.item.relation.status.published": "published",

--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -198,7 +198,7 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
         ));
       }
     }
-    const result = commonService
+    const result = await commonService
       .analyzeBranch(payload.items, existingEntity)
       .then((auditLogsOperations: ToBeFixed) =>
         Promise.all([

--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -386,7 +386,7 @@ const commonService: (context: StrapiContext) => ICommonService = ({ strapi }) =
           currentItem = item;
         }
         return !isEmpty(items)
-          ? commonService.analyzeBranch(
+          ? await commonService.analyzeBranch(
             items,
             masterEntity,
             currentItem,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/361

## Summary

- when duplication error is encountered descriptive error message is displayed. 

Example:

![image](https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/assets/13495487/740b2947-b235-4a3b-8c75-7ae3784279d4)

- minor styling fixes

## Test Plan

- build admin static content
- start server
- add navigation for already existing path
- click "save" button
- error message should pop-up