### PR TITLE
feat: invalid slug source notification

### DIFF
--- a/admin/src/pages/DataManagerProvider/index.js
+++ b/admin/src/pages/DataManagerProvider/index.js
@@ -369,7 +369,19 @@ const DataManagerProvider = ({ children }) => {
     request(
       `/${pluginId}/slug?q=${query}`,
       { method: "GET", signal }
-    );
+    ).then((res) => {
+      if (!res?.slug) {
+        toggleNotification({
+          type: 'warning',
+          message: formatMessage(
+            getTrad('notification.error.item.slug'),
+            { query, result: res?.slug || "" }
+          )
+        });
+      }
+
+      return res;
+    });
 
   const hardReset = () => getDataRef.current();
 

--- a/admin/src/translations/ca.json
+++ b/admin/src/translations/ca.json
@@ -18,6 +18,7 @@
     "notification.error": "S'ha produït un error en processar la sol·licitud.",
     "notification.error.customField.type": "Tipus de camp personalitzat no compatible",
     "notification.error.item.relation": "Les relacions proporcionades en alguns elements són incorrectes",
+    "notification.error.item.slug": "No es pot crear la clau (slug) vàlida de l'encaminador de la IU des de \"{ query }\". \"{ result }\" rebut",
     "notification.navigation.error": "Camí duplicat: { path } al pare: { parentTitle } per a { errorTitles } elements",
     "notification.navigation.item.relation": "La relació d'entitat no existeix!",
     "notification.navigation.item.relation.status.draft": "esborrany",

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -84,6 +84,7 @@
   "notification.error": "Error while processing request.",
   "notification.error.customField.type": "Unsupported type of custom field",
   "notification.error.item.relation": "Relations provided in some items are incorrect",
+  "notification.error.item.slug": "Unable to create valid UI Router Key(slug) from \"{ query }\". \"{ result }\" received",
   "page.auth.noAccess": "No access",
   "page.auth.not.allowed": "Oops! It seems like You do not have access to this page...",
   "pages.main.search.placeholder": "Type to start searching...",

--- a/admin/src/translations/fr.json
+++ b/admin/src/translations/fr.json
@@ -41,5 +41,6 @@
   "components.navigationItem.action.newItem": "Nouvel élément imbriqué",
 	"components.navigationItem.badge.removed": "Supprimé",
 	"components.navigationItem.badge.draft": "Brouillon",
-	"components.navigationItem.badge.published": "Publié"
+	"components.navigationItem.badge.published": "Publié",
+  "notification.error.item.slug": "Impossible de créer une clé de routeur d'interface utilisateur valide (slug) à partir de \"{ query }\". \"{ result }\" reçu"
 }


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/335

## Summary

- error message for event of strapi being unable to generate `uiRouterKey` from `title`

![image](https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/assets/13495487/9b867782-53f4-46b1-a848-5b9448207e06)


## Test Plan

- build admin UI
- start the app
- try to add navigation item with invalid title (example: all characters non-latin)
- try to save
- notification should pop up