### PR TITLE
fix: graphql filtering by path

### DIFF
--- a/server/services/client.ts
+++ b/server/services/client.ts
@@ -362,8 +362,9 @@ const clientService: (context: StrapiContext) => IClientService = ({ strapi }) =
               return cached;
 
             const item = result.find(item => item.id === id);
+
             if (isNil(item))
-              throw new Error("Item not found");
+              return [0];
 
             const { order, parent } = item;
 
@@ -372,6 +373,7 @@ const clientService: (context: StrapiContext) => IClientService = ({ strapi }) =
               : [order];
 
             cache.set(id, nestedOrders);
+
             return nestedOrders;
           }
 

--- a/server/utils/functions.ts
+++ b/server/utils/functions.ts
@@ -273,7 +273,8 @@ export const buildNestedPaths = <T extends Pick<NavigationItemEntity, 'parent' |
       return (data && data === id) || (isObject(entity.parent) && ((entity.parent).id === id));
     })
     .reduce((acc: NestedPath[], entity) => {
-      const path = `${parentPath || ''}/${entity.path}`
+      const path = `${parentPath || ''}/${entity.path}`.replace("//", "/")
+
       return [
         {
           id: entity.id,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/366

## Summary

- fixes for reading navigation by path

## Test Plan

- start server
- query for a navigation with root path (or any other you like)

Example:

<img width="1003" alt="image" src="https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/assets/13495487/25b9b40e-4584-43ca-b391-1d80169b34dd">
