### PR TITLE
feat: navigation meta data

### DIFF
--- a/admin/src/pages/View/components/NavigationHeader/index.js
+++ b/admin/src/pages/View/components/NavigationHeader/index.js
@@ -5,6 +5,8 @@ import { Stack } from '@strapi/design-system/Stack';
 import { Button } from '@strapi/design-system/Button';
 import Check from '@strapi/icons/Check';
 import More from '@strapi/icons/More';
+import Information from '@strapi/icons/Information';
+import { Tag } from '@strapi/design-system/Tag';
 import { getTrad } from '../../../../translations';
 import { MoreButton } from './styles';
 import { Select, Option } from '@strapi/design-system/Select';
@@ -50,6 +52,20 @@ const NavigationHeader = ({
 
   return (
     <HeaderLayout
+      secondaryAction={
+        <Tag icon={<Information aria-hidden={true} />}>
+          {
+            activeNavigation
+              ? formatMessage(
+                    getTrad('header.meta'),
+                  {
+                    id: activeNavigation?.id,
+                    key: activeNavigation?.slug
+                  })
+              : null
+          }
+        </Tag>
+      }
       primaryAction={
         <Stack horizontal size={2}>
           <Box marginRight="8px">

--- a/admin/src/translations/ca.json
+++ b/admin/src/translations/ca.json
@@ -14,6 +14,7 @@
     "header.action.manage": "Gestionar",
     "header.action.newItem": "Element nou",
     "header.description": "Definiu la vostra navegació del lloc web",
+    "header.meta": "ID: { id }, slug: { key }",
     "header.title": "Navegació",
     "notification.error": "S'ha produït un error en processar la sol·licitud.",
     "notification.error.customField.type": "Tipus de camp personalitzat no compatible",

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -2,6 +2,7 @@
   "plugin.name": "UI Navigation",
   "header.title": "Navigation",
   "header.description": "Define your portal navigation",
+  "header.meta": "ID: { id }, slug: { key }",
   "header.action.newItem": "New Item",
   "header.action.manage": "Manage",
   "header.action.collapseAll": "Collapse All",

--- a/admin/src/translations/fr.json
+++ b/admin/src/translations/fr.json
@@ -2,6 +2,7 @@
   "plugin.name": "UI Navigation",
   "header.title": "Navigation",
   "header.description": "Définisser votre menu de navigation",
+  "header.meta": "ID: { id }, slug: { key }",
   "submit.cta.cancel": "Annuler",
   "submit.cta.save": "Sauvegarder",
   "empty": "Le menu de navigation est vide",


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/370

## Summary

- id and slug of navigation displayed in header

![image](https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/assets/13495487/a590fb16-2d67-41ee-8a26-537032660282)

## Test Plan

- build admin resource
- display navigation details page
- result should be similar to example
- validate displayed `id` and `slug` against details in dev tools' `Network` tab