### PR TITLE
fix: db deadlocks and dup errors

### DIFF
--- a/server/i18n/navigationSetupStrategy.ts
+++ b/server/i18n/navigationSetupStrategy.ts
@@ -1,4 +1,4 @@
-import { IStrapi, OnlyStrings } from "strapi-typed";
+import { IStrapi, OnlyStrings, StrapiDBBulkActionResponse } from "strapi-typed";
 import {
   assertEntity,
   assertNotEmpty,
@@ -7,10 +7,9 @@ import {
   Navigation,
   NavigationPluginConfig,
 } from "../../types";
-import {
-  DEFAULT_NAVIGATION_ITEM, DEFAULT_POPULATE,
-} from "../utils";
+import { DEFAULT_NAVIGATION_ITEM, DEFAULT_POPULATE } from "../utils";
 import { DefaultLocaleMissingError } from "./errors";
+import { prop } from "lodash/fp";
 
 export const i18nNavigationSetupStrategy: INavigationSetupStrategy = async ({
   strapi,
@@ -40,67 +39,74 @@ export const i18nNavigationSetupStrategy: INavigationSetupStrategy = async ({
       ];
     }
 
-    if (currentNavigations.some(hasNotAnyLocale)) {
-      currentNavigations = await Promise.all(
-        currentNavigations.map(async (navigation) => {
-          return hasNotAnyLocale(navigation)
-            ? await updateNavigation({
-                strapi,
-                current: navigation,
-                payload: {
-                  localeCode: defaultLocale,
-                },
-                populate: DEFAULT_POPULATE,
-              })
-            : navigation;
-        })
-      );
-    }
+    const noLocaleNavigations = currentNavigations.filter(hasNotAnyLocale);
 
-    await Promise.all(
-      currentNavigations
-        .filter(({ localeCode }) => defaultLocale === localeCode)
-        .flatMap(async (rootNavigation) => {
-          const localizations = [
-            ...(rootNavigation.localizations ?? []).map<Navigation>(
-              (localization) => assertEntity(localization, "Navigation")
-            ),
-            rootNavigation,
-          ];
-
-          for (const locale of allLocale) {
-            if (
-              !localizations.some(({ localeCode }) => localeCode === locale)
-            ) {
-              localizations.push(
-                await createNavigation({
-                  strapi,
-                  payload: {
-                    localeCode: locale,
-                    slug: `${rootNavigation.slug}-${locale}`,
-                    name: rootNavigation.name,
-                    visible: true,
-                  },
-                })
-              );
-            }
+    if (noLocaleNavigations.length) {
+      await updateNavigations({
+        strapi,
+        ids: noLocaleNavigations.map(prop("id")).reduce((acc, id) => {
+          if (id && Number(id)) {
+            acc.push(Number(id));
           }
 
-          return await Promise.all(
-            localizations.map((current) =>
-              updateNavigation({
-                strapi,
-                current,
-                payload: {
-                  localizations: localizations.filter(
-                    ({ id }) => id !== current.id
-                  ),
-                },
-              })
-            )
-          );
-        })
+          return acc;
+        }, [] as Array<number>),
+        payload: {
+          localeCode: defaultLocale,
+        },
+        populate: DEFAULT_POPULATE,
+      });
+
+      currentNavigations = await getCurrentNavigations(strapi);
+    }
+
+    const navigationsToProcess = currentNavigations.filter(
+      ({ localeCode }) => defaultLocale === localeCode
     );
+
+    for (const rootNavigation of navigationsToProcess) {
+      let localizations = [
+        ...(rootNavigation.localizations ?? []).map<Navigation>(
+          (localization) => assertEntity(localization, "Navigation")
+        ),
+        rootNavigation,
+      ];
+
+      const missingLocale = allLocale.filter(
+        (locale) =>
+          !localizations.some(({ localeCode }) => localeCode === locale)
+      );
+
+      if (missingLocale.length) {
+        const { ids } = await createNavigations({
+          strapi,
+          payloads: missingLocale.map((locale) => ({
+            localeCode: locale,
+            slug: `${rootNavigation.slug}-${locale}`,
+            name: rootNavigation.name,
+            visible: true,
+          })),
+        });
+
+        localizations = [...(await getCurrentNavigations(strapi, ids))].concat([
+          rootNavigation,
+        ]);
+      }
+
+      // TODO: Update to bulk operation when strapi
+      // allows to update `oneToMany` relations on bulk update
+      for (const current of localizations) {
+        await updateNavigation({
+          strapi,
+          current,
+          payload: {
+            localizations: localizations.filter(
+              (localization) => localization.id !== current.id
+            ),
+          },
+        });
+      }
+    }
   } else {
     if (config.pruneObsoleteI18nNavigations) {
       await deleteNavigations({
@@ -125,8 +131,11 @@ export const i18nNavigationSetupStrategy: INavigationSetupStrategy = async ({
   return getCurrentNavigations(strapi);
 };
 
-const getCurrentNavigations = (strapi: IStrapi): Promise<Navigation[]> =>
-  strapi.plugin("navigation").service("admin").get();
+const getCurrentNavigations = (
+  strapi: IStrapi,
+  ids?: Array<number>
+): Promise<Navigation[]> =>
+  strapi.plugin("navigation").service("admin").get(ids);
 
 // TODO: Move to service
 const createNavigation = ({
@@ -145,7 +154,21 @@ const createNavigation = ({
     populate,
   });
 
-// TODO: Move to service
+// TODO: update strapi-typed
+const createNavigations = ({
+  strapi,
+  payloads,
+  populate,
+}: {
+  strapi: IStrapi;
+  payloads: Array<Partial<Navigation>>;
+  populate?: Array<keyof Navigation>;
+}): Promise<any> =>
+  strapi.query<Navigation>("plugin::navigation.navigation").createMany({
+    data: payloads,
+    populate,
+  });
+
 const updateNavigation = ({
   strapi,
   current,
@@ -167,6 +190,27 @@ const updateNavigation = ({
     },
   });
 
+const updateNavigations = ({
+  strapi,
+  ids,
+  payload,
+  populate,
+}: {
+  strapi: IStrapi;
+  payload: Partial<Navigation>;
+  ids: Array<number>;
+  populate?: Array<OnlyStrings<keyof Navigation>>;
+}): Promise<StrapiDBBulkActionResponse> =>
+  strapi.query<Navigation>("plugin::navigation.navigation").updateMany({
+    data: payload,
+    populate,
+    where: {
+      id: {
+        $in: ids,
+      },
+    },
+  });
+
 // TODO: Move to service
 const deleteNavigations = ({
   strapi,
@@ -179,14 +223,18 @@ const deleteNavigations = ({
     where,
   });
 
-const createDefaultI18nNavigation = ({ strapi, defaultLocale }: {
+const createDefaultI18nNavigation = ({
+  strapi,
+  defaultLocale,
+}: {
   strapi: IStrapi;
   defaultLocale: string;
-}): Promise<Navigation> => createNavigation({
-  strapi,
-  payload: {
-    ...DEFAULT_NAVIGATION_ITEM,
-    localeCode: defaultLocale,
-  },
-  populate: DEFAULT_POPULATE,
-});
+}): Promise<Navigation> =>
+  createNavigation({
+    strapi,
+    payload: {
+      ...DEFAULT_NAVIGATION_ITEM,
+      localeCode: defaultLocale,
+    },
+    populate: DEFAULT_POPULATE,
+  });

--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -433,14 +433,12 @@ const commonService: (context: StrapiContext) => ICommonService = ({ strapi }) =
       return acc.map((item) => omit(item, [`additionalFields.${curr.name}`]) as NavigationItemEntity);
     }, navigationItems);
 
-    await Promise.all(
-      navigationItemsToUpdate.map(async (item) =>
-        await databaseModel.update({
-          where: { id: item.id },
-          data: { additionalFields: item.additionalFields },
-        })
-      )
-    );
+    for (const item of navigationItemsToUpdate) {
+      await databaseModel.update({
+        where: { id: item.id },
+        data: { additionalFields: item.additionalFields },
+      })
+    }
   },
 
   async getSlug(query) {

--- a/types/services.ts
+++ b/types/services.ts
@@ -9,7 +9,7 @@ export type NavigationService = ICommonService | IAdminService | IClientService
 
 export interface IAdminService {
   config: (viaSettingsPage?: boolean) => Promise<NavigationPluginConfig>,
-  get: () => Promise<Navigation[]>,
+  get: (ids?: Array<number>) => Promise<Navigation[]>,
   getById: (id: Id) => Promise<Navigation>,
   post: (payload: ToBeFixed, auditLog: AuditLogContext) => ToBeFixed,
   put: (id: Id, payload: ToBeFixed, auditLog: AuditLogContext) => ToBeFixed,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/347
https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/345

## Summary

DB transactions issues on creating localisations of navigation(s). Parallel db queries were changed to synchronised async calls and bulk operations where possible.

## Test Plan

- create navigation with disabled i18n on server (or delete all current navigations)
- start server
- server should be able to startup
- enable i18n
- restart server
- existing navigations should be localised to default locale
- localisations should be created and connected to main navigation
- add new language as supported 
- restart server
- localisations for newly added language should be present
- go to navigation section in admin panel
- add new navigation
- delete newly created navigation
- navigation should be removed with no issues, localisation should be cleaned up