### PR TITLE
fix: cascade navigation deletion

### DIFF
--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { errors } from "@strapi/utils"
+import { errors } from "@strapi/utils";
 import { differenceBy, get, isEmpty, isNil, isObject } from "lodash";
 import { Id, StrapiContext } from "strapi-typed";
 import {
@@ -8,10 +8,11 @@ import {
   IAdminService,
   ICommonService,
   Navigation,
+  NavigationItem,
   NavigationItemCustomField,
   NavigationItemEntity,
   NavigationPluginConfig,
-  ToBeFixed
+  ToBeFixed,
 } from "../../types";
 import {
   ALLOWED_CONTENT_TYPES,
@@ -25,17 +26,28 @@ import {
   sendAuditLog,
   validateAdditionalFields,
 } from "../utils";
-import { addI18NConfigFields, getI18nStatus, I18NConfigFields, i18nNavigationContentsCopy, i18nNavigationSetupStrategy, i18nNavigationItemRead } from "../i18n";
+import {
+  addI18NConfigFields,
+  getI18nStatus,
+  I18NConfigFields,
+  i18nNavigationContentsCopy,
+  i18nNavigationSetupStrategy,
+  i18nNavigationItemRead,
+} from "../i18n";
 import { NavigationError } from "../../utils/NavigationError";
 
-type SettingsPageConfig = NavigationPluginConfig & I18NConfigFields
+type SettingsPageConfig = NavigationPluginConfig & I18NConfigFields;
 
-const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => ({
+const adminService: (context: StrapiContext) => IAdminService = ({
+  strapi,
+}) => ({
   async config(viaSettingsPage = false): Promise<SettingsPageConfig> {
-    const commonService = getPluginService<ICommonService>('common');
+    const commonService = getPluginService<ICommonService>("common");
     const { audienceModel } = getPluginModels();
-    const pluginStore = await commonService.getPluginStore()
-    const config = await pluginStore.get<string, NavigationPluginConfig>({ key: 'config' });
+    const pluginStore = await commonService.getPluginStore();
+    const config = await pluginStore.get<string, NavigationPluginConfig>({
+      key: "config",
+    });
 
     const additionalFields = config.additionalFields;
     const cascadeMenuAttached = config.cascadeMenuAttached;
@@ -43,7 +55,7 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
     const contentTypesPopulate = config.contentTypesPopulate;
     const pathDefaultFields = config.pathDefaultFields;
     const allowedLevels = config.allowedLevels;
-    const isGQLPluginEnabled = !isNil(strapi.plugin('graphql'));
+    const isGQLPluginEnabled = !isNil(strapi.plugin("graphql"));
 
     let extendedResult: Record<string, unknown> = {
       allowedContentTypes: ALLOWED_CONTENT_TYPES,
@@ -56,21 +68,31 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
         default: CONTENT_TYPES_NAME_FIELDS_DEFAULTS,
         ...(isObject(contentTypesNameFields) ? contentTypesNameFields : {}),
       },
-      contentTypesPopulate: isObject(contentTypesPopulate) ? contentTypesPopulate : {},
+      contentTypesPopulate: isObject(contentTypesPopulate)
+        ? contentTypesPopulate
+        : {},
       pathDefaultFields: isObject(pathDefaultFields) ? pathDefaultFields : {},
       allowedLevels,
       additionalFields: viaSettingsPage
         ? additionalFields
-        : additionalFields.filter(field => typeof field === 'string' || get(field, 'enabled', false)),
+        : additionalFields.filter(
+            (field) => typeof field === "string" || get(field, "enabled", false)
+          ),
       gql: {
-        navigationItemRelated: configContentTypes.map(({ labelSingular }) => labelSingular.replace(/\s+/g, ''))
+        navigationItemRelated: configContentTypes.map(({ labelSingular }) =>
+          labelSingular.replace(/\s+/g, "")
+        ),
       },
       isGQLPluginEnabled: viaSettingsPage ? isGQLPluginEnabled : undefined,
       cascadeMenuAttached,
     };
-    const i18nConfig = await addI18NConfigFields({ strapi, viaSettingsPage, previousConfig: {} });
+    const i18nConfig = await addI18NConfigFields({
+      strapi,
+      viaSettingsPage,
+      previousConfig: {},
+    });
 
-    if (additionalFields.includes('audience')) {
+    if (additionalFields.includes("audience")) {
       const audienceItems = await strapi
         .query<Audience>(audienceModel.uid)
         .findMany({
@@ -90,22 +112,22 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
 
   async get(ids): Promise<Navigation[]> {
     const { masterModel } = getPluginModels();
-    const entities = await strapi
-      .query<Navigation>(masterModel.uid)
-      .findMany({
-        limit: Number.MAX_SAFE_INTEGER,
-        populate: DEFAULT_POPULATE,
-        where: ids ? {
-          id: {
-            $in: ids
+    const entities = await strapi.query<Navigation>(masterModel.uid).findMany({
+      limit: Number.MAX_SAFE_INTEGER,
+      populate: DEFAULT_POPULATE,
+      where: ids
+        ? {
+            id: {
+              $in: ids,
+            },
           }
-        } : undefined
-      });
+        : undefined,
+    });
     return entities;
   },
 
   async getById(id: Id): Promise<Navigation> {
-    const commonService = getPluginService<ICommonService>('common');
+    const commonService = getPluginService<ICommonService>("common");
 
     const { masterModel, itemModel } = getPluginModels();
     const entity = await strapi
@@ -119,8 +141,8 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
           master: id,
         },
         limit: Number.MAX_SAFE_INTEGER,
-        orderBy: [{ order: 'asc', }],
-        populate: ['related', 'parent', 'audience']
+        orderBy: [{ order: "asc" }],
+        populate: ["related", "parent", "audience"],
       });
     const entities = await commonService.getRelatedItems(entityItems);
     return {
@@ -130,9 +152,11 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
   },
 
   async post(payload: ToBeFixed, auditLog: AuditLogContext) {
-    const commonService = getPluginService<ICommonService>('common');
-    const adminService = getPluginService<IAdminService>('admin');
-    const { enabled: i18nEnabled, defaultLocale } = await getI18nStatus({ strapi })
+    const commonService = getPluginService<ICommonService>("common");
+    const adminService = getPluginService<IAdminService>("admin");
+    const { enabled: i18nEnabled, defaultLocale } = await getI18nStatus({
+      strapi,
+    });
 
     const { masterModel } = getPluginModels();
     const { name, visible } = payload;
@@ -140,7 +164,7 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
       name,
       slug: await commonService.getSlug(name),
       visible,
-    }
+    };
 
     const existingEntity = await strapi
       .query<Navigation>(masterModel.uid)
@@ -150,34 +174,48 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
       .createBranch(payload.items, existingEntity, null, {})
       .then(() => adminService.getById(existingEntity.id))
       .then((newEntity: Navigation) => {
-        sendAuditLog(auditLog, 'onChangeNavigation',
-          { actionType: 'CREATE', oldEntity: existingEntity, newEntity });
+        sendAuditLog(auditLog, "onChangeNavigation", {
+          actionType: "CREATE",
+          oldEntity: existingEntity,
+          newEntity,
+        });
         return newEntity;
       });
 
-    await commonService.emitEvent(masterModel.uid, 'entry.create', existingEntity);
+    await commonService.emitEvent(
+      masterModel.uid,
+      "entry.create",
+      existingEntity
+    );
 
     if (i18nEnabled && defaultLocale) {
       await i18nNavigationSetupStrategy({ strapi });
     }
 
-    return result
+    return result;
   },
 
-  async put(id: Id, payload: Navigation & { items: ToBeFixed }, auditLog: AuditLogContext) {
-    const adminService = getPluginService<IAdminService>('admin');
-    const commonService = getPluginService<ICommonService>('common');
-    const { enabled: i18nEnabled } = await getI18nStatus({ strapi })
+  async put(
+    id: Id,
+    payload: Navigation & { items: ToBeFixed },
+    auditLog: AuditLogContext
+  ) {
+    const adminService = getPluginService<IAdminService>("admin");
+    const commonService = getPluginService<ICommonService>("common");
+    const { enabled: i18nEnabled } = await getI18nStatus({ strapi });
 
     const { masterModel } = getPluginModels();
     const { name, visible } = payload;
 
     const existingEntity = await adminService.getById(id);
-    const detailsHaveChanged = existingEntity.name !== name || existingEntity.visible !== visible;
+    const detailsHaveChanged =
+      existingEntity.name !== name || existingEntity.visible !== visible;
 
     if (detailsHaveChanged) {
       const newName = detailsHaveChanged ? name : existingEntity.name;
-      const newSlug = detailsHaveChanged ? await commonService.getSlug(name) : existingEntity.slug;
+      const newSlug = detailsHaveChanged
+        ? await commonService.getSlug(name)
+        : existingEntity.slug;
 
       await strapi.query<Navigation>(masterModel.uid).update({
         where: { id },
@@ -199,7 +237,7 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
               slug: `${newSlug}-${locale.localeCode}`,
               visible,
             },
-          })
+          });
         }
       }
     }
@@ -207,43 +245,78 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
       .analyzeBranch(payload.items, existingEntity)
       .then((auditLogsOperations: ToBeFixed) =>
         Promise.all([
-          auditLog ? prepareAuditLog((auditLogsOperations || []).flat(Number.MAX_SAFE_INTEGER)) : [],
-          adminService.getById(existingEntity.id)],
-        ))
+          auditLog
+            ? prepareAuditLog(
+                (auditLogsOperations || []).flat(Number.MAX_SAFE_INTEGER)
+              )
+            : [],
+          adminService.getById(existingEntity.id),
+        ])
+      )
       .then(([actionType, newEntity]: ToBeFixed) => {
-        sendAuditLog(auditLog, 'onChangeNavigation',
-          { actionType, oldEntity: existingEntity, newEntity });
+        sendAuditLog(auditLog, "onChangeNavigation", {
+          actionType,
+          oldEntity: existingEntity,
+          newEntity,
+        });
         return newEntity;
       });
 
-    const navigationEntity = await strapi.query<Navigation>(masterModel.uid).findOne({ where: { id } });
-    await commonService.emitEvent(masterModel.uid, 'entry.update', navigationEntity);
-    return result
+    const navigationEntity = await strapi
+      .query<Navigation>(masterModel.uid)
+      .findOne({ where: { id } });
+    await commonService.emitEvent(
+      masterModel.uid,
+      "entry.update",
+      navigationEntity
+    );
+    return result;
   },
 
   async delete(id, auditLog) {
-    const { masterModel } = getPluginModels();
-    const adminService = getPluginService<IAdminService>('admin');
+    const { masterModel, itemModel } = getPluginModels();
+    const adminService = getPluginService<IAdminService>("admin");
     const entity = await adminService.getById(id);
-    const { enabled: i18nEnabled } = await getI18nStatus({ strapi })
+    const { enabled: i18nEnabled } = await getI18nStatus({ strapi });
+    // TODO: remove when cascade deletion is present
+    // NOTE: Delete many with relation `where` crashes ORM
+    const cleanNavigationItems = async (masterIds: Array<Id>) => {
+      const navigationItems = await strapi.query<NavigationItem>(itemModel.uid).findMany({
+        where: {
+          $or: masterIds.map((id) => ({ master: id }))
+        },
+        limit: Number.MAX_SAFE_INTEGER,
+      });
 
+      await strapi.query<NavigationItem>(itemModel.uid).deleteMany({
+        where: {
+          $or: navigationItems.map(({ id }) => ({ id }))
+        },
+      });
+    };
+
+    await cleanNavigationItems([id]);
     await strapi.query<Navigation>(masterModel.uid).delete({
       where: {
         id,
-      }
+      },
     });
 
     if (i18nEnabled && entity.localizations) {
+      await cleanNavigationItems(entity.localizations.map(_ => _.id));
       await strapi.query<Navigation>(masterModel.uid).deleteMany({
         where: {
           id: {
-            $in: entity.localizations.map(_ => _.id),
-          }
-        }
+            $in: entity.localizations.map((_) => _.id),
+          },
+        },
       });
     }
 
-    sendAuditLog(auditLog, 'onNavigationDeletion', { entity, actionType: "DELETE" });
+    sendAuditLog(auditLog, "onNavigationDeletion", {
+      entity,
+      actionType: "DELETE",
+    });
   },
 
   async restart(): Promise<void> {
@@ -251,34 +324,40 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
   },
 
   async restoreConfig(): Promise<void> {
-    const commonService = getPluginService<ICommonService>('common');
+    const commonService = getPluginService<ICommonService>("common");
     const pluginStore = await commonService.getPluginStore();
-    await pluginStore.delete({ key: 'config' });
+    await pluginStore.delete({ key: "config" });
     await commonService.setDefaultConfig();
   },
 
   async updateConfig(newConfig: NavigationPluginConfig): Promise<void> {
-    const commonService = getPluginService<ICommonService>('common');
-    const pluginStore = await commonService.getPluginStore()
-    const config = await pluginStore.get<string, NavigationPluginConfig>({ key: 'config' });
+    const commonService = getPluginService<ICommonService>("common");
+    const pluginStore = await commonService.getPluginStore();
+    const config = await pluginStore.get<string, NavigationPluginConfig>({
+      key: "config",
+    });
     validateAdditionalFields(newConfig.additionalFields);
-    await pluginStore.set({ key: 'config', value: newConfig });
+    await pluginStore.set({ key: "config", value: newConfig });
 
-    const removedFields = differenceBy(config.additionalFields, newConfig.additionalFields, 'name').filter(i => i !== 'audience') as NavigationItemCustomField[];
+    const removedFields = differenceBy(
+      config.additionalFields,
+      newConfig.additionalFields,
+      "name"
+    ).filter((i) => i !== "audience") as NavigationItemCustomField[];
     if (!isEmpty(removedFields)) {
       await commonService.pruneCustomFields(removedFields);
     }
   },
 
   async fillFromOtherLocale({ target, source, auditLog }) {
-    const { enabled } = await getI18nStatus({ strapi })
+    const { enabled } = await getI18nStatus({ strapi });
 
     if (!enabled) {
       throw new NavigationError("Not yet implemented.");
     }
 
-    const adminService = getPluginService<IAdminService>('admin');
-    const commonService = getPluginService<ICommonService>('common');
+    const adminService = getPluginService<IAdminService>("admin");
+    const commonService = getPluginService<ICommonService>("common");
     const targetEntity = await adminService.getById(target);
 
     return await i18nNavigationContentsCopy({
@@ -289,8 +368,11 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
     })
       .then(() => adminService.getById(target))
       .then((updated) => {
-        sendAuditLog(auditLog, 'onChangeNavigation',
-          { actionType: 'UPDATE', oldEntity: targetEntity, newEntity: updated });
+        sendAuditLog(auditLog, "onChangeNavigation", {
+          actionType: "UPDATE",
+          oldEntity: targetEntity,
+          newEntity: updated,
+        });
         return updated;
       });
   },
@@ -299,11 +381,15 @@ const adminService: (context: StrapiContext) => IAdminService = ({ strapi }) => 
     const targetNavigation = await this.getById(target);
 
     if (!sourceNavigation) {
-      throw new errors.NotFoundError("Unable to find source navigation for specified query");
+      throw new errors.NotFoundError(
+        "Unable to find source navigation for specified query"
+      );
     }
 
     if (!targetNavigation) {
-      throw new errors.NotFoundError("Unable to find target navigation for specified query");
+      throw new errors.NotFoundError(
+        "Unable to find target navigation for specified query"
+      );
     }
 
     return await i18nNavigationItemRead({


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/378

## Summary

What does this PR do/solve? 

- On navigation deletion navigation items are manually removed (cascade relation cleanup is not provided by Strapi at the moment)

## Test Plan

- create a navigation
- create some navigation items
- check navigation/navigation items status in DB

```sql
select * from navigations;
select * from navigations_items;
```

- remove newly created navigation
- check navigation/navigation items status in DB
- navigation and it's items should be removed