### PR TITLE
feat: read all navigations

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,73 @@ Plugin supports both **REST API** and **GraphQL API** exposed by Strapi.
 > Version `v2.0.13` introduced breaking change!
 > All responses have changed their structure. Related field will now be of type ContentType instead of Array\<ContentType\>
 
+`GET <host>/api/navigation/?locale=<locale>&orderBy=<orderBy>&orderDirection=<orderDirection>`
+
+NOTE: All params are optional
+
+**Example URL**: `https://localhost:1337/api/navigation?locale=en`
+
+**Example response body**
+
+```json
+[
+  {
+    "id": 383,
+    "name": "Floor",
+    "slug": "floor-pl",
+    "visible": true,
+    "createdAt": "2023-09-29T12:45:54.399Z",
+    "updatedAt": "2023-09-29T13:44:08.702Z",
+    "localeCode": "pl"
+  },
+  {
+    "id": 384,
+    "name": "Floor",
+    "slug": "floor-fr",
+    "visible": true,
+    "createdAt": "2023-09-29T12:45:54.399Z",
+    "updatedAt": "2023-09-29T13:44:08.725Z",
+    "localeCode": "fr"
+  },
+  {
+    "id": 382,
+    "name": "Floor",
+    "slug": "floor",
+    "visible": true,
+    "createdAt": "2023-09-29T12:45:54.173Z",
+    "updatedAt": "2023-09-29T13:44:08.747Z",
+    "localeCode": "en"
+  },
+  {
+    "id": 374,
+    "name": "Main navigation",
+    "slug": "main-navigation-pl",
+    "visible": true,
+    "createdAt": "2023-09-29T12:22:30.373Z",
+    "updatedAt": "2023-09-29T13:44:08.631Z",
+    "localeCode": "pl"
+  },
+  {
+    "id": 375,
+    "name": "Main navigation",
+    "slug": "main-navigation-fr",
+    "visible": true,
+    "createdAt": "2023-09-29T12:22:30.373Z",
+    "updatedAt": "2023-09-29T13:44:08.658Z",
+    "localeCode": "fr"
+  },
+  {
+    "id": 373,
+    "name": "Main navigation",
+    "slug": "main-navigation",
+    "visible": true,
+    "createdAt": "2023-09-29T12:22:30.356Z",
+    "updatedAt": "2023-09-29T13:44:08.680Z",
+    "localeCode": "en"
+  }
+]
+```
+
 `GET <host>/api/navigation/render/<navigationIdOrSlug>?type=<type>`
 
 Return a rendered navigation structure depends on passed type (`TREE`, `RFR` or nothing to render as `FLAT`).

--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -9,6 +9,23 @@ const clientControllers: IClientController = {
     return getPluginService<T>(name);
   },
 
+  async readAll(ctx) {
+    const { query = {} } = ctx;
+    const { locale, orderBy, orderDirection } = query;
+
+    try {
+      return await this.getService().readAll({
+        locale, orderBy, orderDirection 
+      });
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        return ctx.badRequest(error.message)
+      }
+
+      throw error
+    }
+  },
+
   async render(ctx) {
     const { params, query = {} } = ctx;
     const { type, menu: menuOnly, path: rootPath, locale, populate } = query;

--- a/server/routes/client.ts
+++ b/server/routes/client.ts
@@ -18,6 +18,14 @@ const routes: StrapiRoutes = {
       config: {
         policies: []
       }
+    },
+    {
+      method: "GET",
+      path: "/",
+      handler: "client.readAll",
+      config: {
+        policies: []
+      }
     }
   ]
 }

--- a/server/services/client.ts
+++ b/server/services/client.ts
@@ -9,6 +9,25 @@ import { i18nAwareEntityReadHandler } from "../i18n";
 import { NavigationError } from "../../utils/NavigationError";
 
 const clientService: (context: StrapiContext) => IClientService = ({ strapi }) => ({
+  async readAll({ locale, orderBy = 'createdAt', orderDirection = "DESC" }) {
+    const { masterModel } = getPluginModels();
+
+    const navigations = await strapi
+      .query<Navigation>(masterModel.uid)
+      .findMany({
+        where: locale
+          ? {
+              localeCode: locale,
+            }
+          : undefined,
+        orderBy: { [orderBy]: orderDirection } as ToBeFixed,
+        limit: Number.MAX_SAFE_INTEGER,
+        populate: false
+      });
+
+    return navigations;
+  },
+
   async render({
     idOrSlug,
     type = RENDER_TYPES.FLAT,

--- a/types/controllers.ts
+++ b/types/controllers.ts
@@ -35,6 +35,7 @@ export interface IClientController {
 
   render: (ctx: StrapiControllerContext) => ToBeFixed;
   renderChild: (ctx: StrapiControllerContext) => ToBeFixed;
+  readAll: (ctx: StrapiControllerContext) => ToBeFixed;
 };
 
 export type NavigationController = {

--- a/types/services.ts
+++ b/types/services.ts
@@ -44,6 +44,7 @@ export interface ICommonService {
 }
 
 export interface IClientService {
+  readAll: (input: { orderBy?: string, orderDirection?: string } & I18nQueryParams) => Promise<ToBeFixed>,
   render: (input: { idOrSlug: Id, type?: RenderType, menuOnly?: boolean, rootPath?: string, wrapRelated?: boolean, populate?: PopulateQueryParam } & I18nQueryParams) => Promise<ToBeFixed>,
   renderChildren: (input: { idOrSlug: Id, childUIKey: string, type?: RenderType, menuOnly?: boolean, wrapRelated?: boolean } & I18nQueryParams) => Promise<ToBeFixed>,
   renderRFR: (input: { items: NestedStructure<NavigationItem>[], parent?: Id | null, parentNavItem?: RFRNavItem | null, contentTypes: string[], enabledCustomFieldsNames: string[] }) => ToBeFixed,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/379

## Summary

What does this PR do/solve? 

- this PR introduces new endpoint for listing navigations

## Test Plan

- start the server
- make a request (for example: `http://localhost:1337/api/navigation/?locale=en&orderBy=id&orderDirection=DESC`)
- a list of navigations should be returned