### PR TITLE
fix: audience on navigation item

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/index.tsx
+++ b/admin/src/pages/View/components/NavigationItemForm/index.tsx
@@ -94,7 +94,7 @@ const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
       type: get(data, "type", formDefinition.defaultValues.type),
       related: get(data, "related.value", formDefinition.defaultValues.related),
       relatedType: get(data, "relatedType.value", formDefinition.defaultValues.relatedType),
-      audience: get(data, "audience", formDefinition.defaultValues.audience).map((item: Audience | Id) => isObject(item) ? item.id : item),
+      audience: get(data, "audience", formDefinition.defaultValues.audience).map((item: Audience | Id) => isObject(item) ? item.id.toString() : item.toString()),
       additionalFields: getDefaultCustomFields({
         additionalFields,
         customFieldsValues: get(data, "additionalFields", []),


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/364

## Summary

What does this PR do/solve? 

- fix for audience being set yet not visible on navigation item form

## Test Plan

- start an app
- add audience to navigation item
- save navigation
- reload page
- view navigation item
- set audience should be visible
