### PR TITLE
Add a workaround to prevent unintentional modal closing

### DIFF
--- a/admin/src/pages/View/index.js
+++ b/admin/src/pages/View/index.js
@@ -241,7 +241,15 @@ const View = () => {
   const onPopUpClose = (e) => {
     e.preventDefault();
     e.stopPropagation();
-    changeNavigationItemPopupState(false);
+    
+    // Using Strapi design system select components inside a modal causes
+    // extraneous close events to be fired. It is most likely related to how
+    // the select component handles onOutsideClick events. In those situations
+    // the event target element is the root HTML element.
+    // This is a workaround to prevent the modal from closing in those cases.
+    if (e.target.tagName !== 'HTML') {
+      changeNavigationItemPopupState(false);
+    }
   };
 
   const handleChangeNavigationSelection = (...args) => {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/384

## Summary

Fixes the bug related to unintentional modal closes when not selecting a value from a select inside the navigation item editor modal

## Test Plan

Verified by manual testing of the UI.

`@strapi/strapi 4.15.0`
`strapi-plugin-navigation 2.2.16`

1. Open navigation item edit popup (create or edit existing)
2. Open any select component
3. Click inside of the modal but outside of the select
4. Verify that the select is closed but the modal remains open
5. Click outside of the modal
6. Verify that the modal has closed
