### PR TITLE
Fix related entity title parsing bug

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/index.tsx
+++ b/admin/src/pages/View/components/NavigationItemForm/index.tsx
@@ -221,7 +221,7 @@ const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
       return isString(title) && !isEmpty(title) ? await slugify(title).then(prop("slug")) : undefined;
     } else if (related) {
       const relationTitle = extractRelatedItemLabel({
-        ...contentTypeEntities.find(_ => String(_.id) === related),
+        ...contentTypeEntities.find(_ => String(_.id) === String(related)),
         __collectionUid: relatedType
       }, contentTypesNameFields, { contentTypes });
       return isString(relationTitle) && !isEmpty(relationTitle) ? await slugify(relationTitle).then(prop("slug")) : undefined;

--- a/admin/src/pages/View/components/NavigationItemForm/index.tsx
+++ b/admin/src/pages/View/components/NavigationItemForm/index.tsx
@@ -221,7 +221,7 @@ const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
       return isString(title) && !isEmpty(title) ? await slugify(title).then(prop("slug")) : undefined;
     } else if (related) {
       const relationTitle = extractRelatedItemLabel({
-        ...contentTypeEntities.find(_ => _.id === related),
+        ...contentTypeEntities.find(_ => String(_.id) === related),
         __collectionUid: relatedType
       }, contentTypesNameFields, { contentTypes });
       return isString(relationTitle) && !isEmpty(relationTitle) ? await slugify(relationTitle).then(prop("slug")) : undefined;


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/350

## Summary

Fixes #350. The content type title value was not pulled correctly from the contentTypeEntities-array. The reason was that the comparison against the `related` id failed because one of the values was a string and the other was a number.

## Test Plan

`@strapi/strapi 4.15.0`
`strapi-plugin-navigation 2.2.16`

1. Create or edit a navigation item
2. Make sure that the title field is empty
3. Select a related entity with a valid name field configuration
4. Click the save button
5. The navigation item is saved