### PR TITLE
fix: navigation bootstrap orphan connections

### DIFF
--- a/server/i18n/navigationSetupStrategy.ts
+++ b/server/i18n/navigationSetupStrategy.ts
@@ -69,8 +69,23 @@ export const i18nNavigationSetupStrategy: INavigationSetupStrategy = async ({
         ...(rootNavigation.localizations ?? []).map<Navigation>(
           (localization) => assertEntity(localization, "Navigation")
         ),
-        rootNavigation,
       ];
+
+      const connectOrphans = currentNavigations.filter((navigation) => {
+        return (
+          navigation.slug.startsWith(rootNavigation.slug) &&
+          navigation.id !== rootNavigation.id &&
+          !localizations.find(({ id }) => navigation.id === id)
+        );
+      });
+
+      localizations = localizations
+        .concat([rootNavigation])
+        .concat(connectOrphans)
+        // hiding not supported locale versions
+        .filter(
+          ({ localeCode }) => !!localeCode && allLocale.includes(localeCode)
+        );
 
       const missingLocale = allLocale.filter(
         (locale) =>


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/390

## Summary

What does this PR do/solve? 

In case of adding new locale version previous localisations happend to be disconnected from main one. Because of this bootstrapper tried to create navigations for locale that already exists.

This fix compensates for any connections lost that may happen when adding or removing locale version.

## Test Plan

- start server
- add new locale version
- restart server
- restart server
- visit UI navigation section
- new locale version should be added to navigation(s)
- already existing locale version should persist 