### PR TITLE
fix: sensitive info leak due to populate field

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "publish:latest": "cd build && npm publish --tag latest",
     "prepublish:latest": "npm run clean && npm run build && node build/setup-package.js",
     "test:unit": "jest --verbose --coverage",
+    "test:unit:watch": "jest --watch",
     "build": "tsc",
     "build:dev": "npm run build && cp ./package.json ./build && cd ./build && yarn",
     "clean": "rm -rf build",

--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -1,11 +1,19 @@
 //@ts-ignore
-import { errors } from '@strapi/utils';
+import { errors, sanitize } from "@strapi/utils";
 import { Id, StringMap } from "strapi-typed";
-import { IClientController, IClientService, NavigationService, NavigationServiceName, ToBeFixed } from "../../types";
-import { getPluginService, parseParams } from "../utils";
+import {
+  IClientController,
+  IClientService,
+  NavigationService,
+  NavigationServiceName,
+  ToBeFixed,
+} from "../../types";
+import { getPluginService, parseParams, sanitizePopulateField } from "../utils";
 
 const clientControllers: IClientController = {
-  getService<T extends NavigationService = IClientService>(name: NavigationServiceName = "client") {
+  getService<T extends NavigationService = IClientService>(
+    name: NavigationServiceName = "client"
+  ) {
     return getPluginService<T>(name);
   },
 
@@ -15,14 +23,16 @@ const clientControllers: IClientController = {
 
     try {
       return await this.getService().readAll({
-        locale, orderBy, orderDirection 
+        locale,
+        orderBy,
+        orderDirection,
       });
     } catch (error: unknown) {
       if (error instanceof Error) {
-        return ctx.badRequest(error.message)
+        return ctx.badRequest(error.message);
       }
 
-      throw error
+      throw error;
     }
   },
 
@@ -39,7 +49,7 @@ const clientControllers: IClientController = {
         menuOnly,
         rootPath,
         locale,
-        populate
+        populate: sanitizePopulateField(populate) as ToBeFixed,
       });
     } catch (error: unknown) {
       if (error instanceof errors.NotFoundError) {
@@ -47,10 +57,10 @@ const clientControllers: IClientController = {
       }
 
       if (error instanceof Error) {
-        return ctx.badRequest(error.message)
+        return ctx.badRequest(error.message);
       }
 
-      throw error
+      throw error;
     }
   },
   async renderChild(ctx) {
@@ -74,10 +84,10 @@ const clientControllers: IClientController = {
       }
 
       if (error instanceof Error) {
-        return ctx.badRequest(error.message)
+        return ctx.badRequest(error.message);
       }
 
-      throw error
+      throw error;
     }
   },
 };

--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -303,13 +303,10 @@ const commonService: (context: StrapiContext) => ICommonService = ({ strapi }) =
     return entityItems
       .map(({ related, ...item }) => {
         const relatedData = data.get(item.id);
+
         if (relatedData) {
           return Object.assign(item, { 
-            related: {
-              ...relatedData,
-              createdBy: purgeSensitiveData(relatedData.createdBy),
-              updatedBy: purgeSensitiveData(relatedData.updatedBy),
-            }
+            related: purgeSensitiveData(relatedData),
           });
         }
         return { ...item, related: null };

--- a/server/utils/__tests__/functions.test.ts
+++ b/server/utils/__tests__/functions.test.ts
@@ -2,7 +2,7 @@ import { IStrapi } from "strapi-typed";
 import { NavigationItemEntity } from "../../../types";
 
 import setupStrapi from '../../../__mocks__/strapi';
-import { buildNestedPaths, filterByPath, getPluginModels, purgeSensitiveData } from "../functions";
+import { buildNestedPaths, filterByPath, getPluginModels, purgeSensitiveDataFromUser } from "../functions";
 
 declare var strapi: IStrapi;
 
@@ -50,16 +50,16 @@ describe('Utilities functions', () => {
 
     it('Filter out sensitive information from related entities', () => {
       const sensitiveDataModel = {
-        name: 'Amy',
+        username: 'Amy',
         password: 'test-password',
         accessToken: 'token',
         reset_token: 'token',
         renewtoken: 'token',
         secret: 'secret'
       };
-      const result = purgeSensitiveData(sensitiveDataModel);
+      const result = purgeSensitiveDataFromUser(sensitiveDataModel);
 
-      expect(result).toHaveProperty('name', 'Amy');
+      expect(result).toHaveProperty('username', 'Amy');
       expect(result).not.toHaveProperty('password');
       expect(result).not.toHaveProperty('accessToken');
       expect(result).not.toHaveProperty('reset_token');

--- a/server/utils/__tests__/functions.test.ts
+++ b/server/utils/__tests__/functions.test.ts
@@ -1,26 +1,33 @@
 import { IStrapi } from "strapi-typed";
 import { NavigationItemEntity } from "../../../types";
 
-import setupStrapi from '../../../__mocks__/strapi';
-import { buildNestedPaths, filterByPath, getPluginModels, purgeSensitiveDataFromUser } from "../functions";
+import setupStrapi from "../../../__mocks__/strapi";
+import {
+  buildNestedPaths,
+  filterByPath,
+  getPluginModels,
+  purgeSensitiveData,
+  purgeSensitiveDataFromUser,
+  sanitizePopulateField,
+} from "../functions";
 
 declare var strapi: IStrapi;
 
-describe('Utilities functions', () => {
+describe("Utilities functions", () => {
   beforeAll(async () => {
     setupStrapi();
   });
 
-  describe('Path rendering functions', () => {
-    it('Can build nested path structure', async () => {
+  describe("Path rendering functions", () => {
+    it("Can build nested path structure", async () => {
       const { itemModel } = getPluginModels();
-      const rootPath = '/home/side';
+      const rootPath = "/home/side";
       const entities = await strapi
         .query<NavigationItemEntity>(itemModel.uid)
         .findMany({
           where: {
-            master: 1
-          }
+            master: 1,
+          },
         });
       const nested = buildNestedPaths(entities);
 
@@ -28,43 +35,144 @@ describe('Utilities functions', () => {
       expect(nested[1].path).toBe(rootPath);
     });
 
-    it('Can filter items by path', async () => {
+    it("Can filter items by path", async () => {
       const { itemModel } = getPluginModels();
-      const rootPath = '/home/side';
+      const rootPath = "/home/side";
       const entities = await strapi
         .query<NavigationItemEntity>(itemModel.uid)
         .findMany({
           where: {
-            master: 1
-          }
+            master: 1,
+          },
         });
-      const {
-        root,
-        items
-      } = filterByPath(entities, rootPath);
+      const { root, items } = filterByPath(entities, rootPath);
 
       expect(root).toBeDefined();
       expect(root?.path).toBe(rootPath);
-      expect(items.length).toBe(1)
+      expect(items.length).toBe(1);
     });
 
-    it('Filter out sensitive information from related entities', () => {
+    it("Filter out sensitive information from related entities", () => {
       const sensitiveDataModel = {
-        username: 'Amy',
-        password: 'test-password',
-        accessToken: 'token',
-        reset_token: 'token',
-        renewtoken: 'token',
-        secret: 'secret'
+        username: "Amy",
+        password: "test-password",
+        accessToken: "token",
+        reset_token: "token",
+        renewtoken: "token",
+        secret: "secret",
       };
       const result = purgeSensitiveDataFromUser(sensitiveDataModel);
 
-      expect(result).toHaveProperty('username', 'Amy');
-      expect(result).not.toHaveProperty('password');
-      expect(result).not.toHaveProperty('accessToken');
-      expect(result).not.toHaveProperty('reset_token');
-      expect(result).not.toHaveProperty('renewtoken');
-      expect(result).not.toHaveProperty('secret');
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "username": "Amy",
+        }
+      `);
+    });
+
+    describe("purgeSensitiveData()", () => {
+      it("should clear user sensitive data from returned entity", () => {
+        const user = {
+          firstname: "Amy",
+          lastname: "Bishop",
+          username: "Amy",
+          password: "test-password",
+          accessToken: "token",
+          reset_token: "token",
+          renewtoken: "token",
+          secret: "secret",
+        };
+        const timestamp = "Thu Dec 21 2023 13:36:46 GMT+0100";
+        const source = {
+          createdBy: user,
+          updatedBy: user,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          content: "Lorem ipsum dolor sit amet",
+          mainImage: {
+            createdBy: user,
+            updatedBy: user,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+            url: "https://lorempixel.com/60x60",
+          },
+        };
+
+        expect(purgeSensitiveData(source)).toMatchInlineSnapshot(`
+          Object {
+            "content": "Lorem ipsum dolor sit amet",
+            "createdAt": "Thu Dec 21 2023 13:36:46 GMT+0100",
+            "createdBy": Object {
+              "firstname": "Amy",
+              "lastname": "Bishop",
+              "username": "Amy",
+            },
+            "mainImage": Object {
+              "createdAt": "Thu Dec 21 2023 13:36:46 GMT+0100",
+              "createdBy": Object {
+                "firstname": "Amy",
+                "lastname": "Bishop",
+                "username": "Amy",
+              },
+              "updatedAt": "Thu Dec 21 2023 13:36:46 GMT+0100",
+              "updatedBy": Object {
+                "firstname": "Amy",
+                "lastname": "Bishop",
+                "username": "Amy",
+              },
+              "url": "https://lorempixel.com/60x60",
+            },
+            "updatedAt": "Thu Dec 21 2023 13:36:46 GMT+0100",
+            "updatedBy": Object {
+              "firstname": "Amy",
+              "lastname": "Bishop",
+              "username": "Amy",
+            },
+          }
+        `);
+      });
+    });
+
+    describe("sanitizePopulateField()", () => {
+      it.each(["*", true, null, undefined])(
+        'should filter out "%s"',
+        (populate: any) => {
+          expect(sanitizePopulateField(populate)).toBe(undefined);
+        }
+      );
+
+      it("should support mapping an array", () => {
+        const populate = ["*", true, null, undefined, "bar"] as any;
+
+        expect(sanitizePopulateField(populate)).toMatchInlineSnapshot(`
+          Array [
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            "bar",
+          ]
+        `);
+      });
+
+      it("should support an object", () => {
+        const populate: any = Object.fromEntries(
+          ["*", true, null, undefined, "bar"].map((value, index) => [
+            `key-${index + 1}`,
+            value,
+          ])
+        );
+
+        expect(sanitizePopulateField(populate)).toMatchInlineSnapshot(`
+          Object {
+            "key-1": undefined,
+            "key-2": undefined,
+            "key-3": undefined,
+            "key-4": undefined,
+            "key-5": "bar",
+          }
+        `);
+      });
     });
   });
 });

--- a/server/utils/functions.ts
+++ b/server/utils/functions.ts
@@ -372,7 +372,7 @@ export const parsePopulateQuery = (populate: PopulateQueryParam): PopulateClause
 }
 
 export const purgeSensitiveData = (data: ToBeFixed): ToBeFixed => {
-  if (!data || !Object.keys(data).length) {
+  if (!data || !(typeof data === "object") || !Object.keys(data).length) {
     return data;
   }
 
@@ -383,7 +383,9 @@ export const purgeSensitiveData = (data: ToBeFixed): ToBeFixed => {
   }
 
   return {
-    ...purgeSensitiveData(rest),
+    ...Object.fromEntries(
+      Object.entries(rest).map(([key, value]) => [key, purgeSensitiveData(value)])
+    ),
     ...(createdBy ? { createdBy: purgeSensitiveDataFromUser(createdBy) } : {}),
     ...(updatedBy ? { updatedBy: purgeSensitiveDataFromUser(updatedBy) } : {}),
   }
@@ -428,8 +430,7 @@ export const sanitizePopulateField = (populate: Populate): Populate => {
 
   if (Array.isArray(populate)) {
     return populate
-      .map((item): Populate => sanitizePopulateField(item))
-      .filter(Boolean);
+      .map((item): Populate => sanitizePopulateField(item));
   }
 
   if ("object" === typeof populate) {

--- a/server/utils/functions.ts
+++ b/server/utils/functions.ts
@@ -39,6 +39,13 @@ import { NavigationError } from '../../utils/NavigationError';
 import { TEMPLATE_DEFAULT, ALLOWED_CONTENT_TYPES, RESTRICTED_CONTENT_TYPES } from './constant';
 declare var strapi: IStrapi;
 
+type Populate =
+  | string
+  | undefined
+  | boolean
+  | Array<Populate>
+  | Record<string, string | boolean | undefined>;
+
 const UID_REGEX = /^(?<type>[a-z0-9-]+)\:{2}(?<api>[a-z0-9-]+)\.{1}(?<contentType>[a-z0-9-]+)$/i;
 
 export const getPluginService = <T extends NavigationService>(name: NavigationServiceName): T =>
@@ -364,17 +371,33 @@ export const parsePopulateQuery = (populate: PopulateQueryParam): PopulateClause
   }
 }
 
-export const purgeSensitiveData = (data: any = {}) => {
+export const purgeSensitiveData = (data: ToBeFixed): ToBeFixed => {
+  if (!data || !Object.keys(data).length) {
+    return data;
+  }
+
+  const { createdBy = undefined, updatedBy = undefined, ...rest } = data;
+
+  if (!createdBy && !updatedBy) {
+    return data;
+  }
+
+  return {
+    ...purgeSensitiveData(rest),
+    ...(createdBy ? { createdBy: purgeSensitiveDataFromUser(createdBy) } : {}),
+    ...(updatedBy ? { updatedBy: purgeSensitiveDataFromUser(updatedBy) } : {}),
+  }
+}
+
+export const purgeSensitiveDataFromUser = (data: any = {}) => {
   if (!data) {
     return undefined;
   }
 
-  const forbiddenFields = ['password', 'token', 'secret'];
+  const allowedFields = ['username', 'firstname', 'lastname', 'email'];
+
   return Object.keys(data)
-    .filter((key: string) => 
-      !forbiddenFields.includes(key.toLowerCase()) &&
-      isEmpty(forbiddenFields.filter(_ => key.toLowerCase().includes(_)))
-    )
+    .filter((key: string) => allowedFields.includes(key.toLowerCase()))
     .reduce((prev, curr) => ({
       ...prev,
       [curr]: data[curr],
@@ -396,4 +419,26 @@ export const resolveGlobalLikeId = (uid = '') =>  {
 
 const splitTypeUid = (uid = '') => {
     return uid.split(UID_REGEX).filter((s) => s && s.length > 0);
+};
+
+export const sanitizePopulateField = (populate: Populate): Populate => {
+  if (!populate || populate === true || populate === "*") {
+    return undefined;
+  }
+
+  if (Array.isArray(populate)) {
+    return populate
+      .map((item): Populate => sanitizePopulateField(item))
+      .filter(Boolean);
+  }
+
+  if ("object" === typeof populate) {
+    return Object.fromEntries(
+      Object.entries(populate).map(
+        ([key, value]) => [key, sanitizePopulateField(value)] as const
+      )
+    ) as Record<string, string | boolean | undefined>;
+  }
+
+  return populate;
 };


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/401

## Summary

- populate clause is sanitised
- `createdBy` and `updatedBy` fields are sanitised and entity is also sanitised recursively 

## Test Plan

- call api on url like `http://localhost:1337/api/navigation/render/<id>?locale=en&populate=*`
- too permissive clauses should be filtered out 