### PR TITLE
feat: lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ Strapi Navigation Plugin provides a website navigation / menu builder feature fo
    - [REST API](#rest-api) 
    - [GraphQL API](#graphql-api)
 10. [🔌 Extensions](#-extensions)
-11. [🧩 Examples](#-examples)
-12. [💬 FAQ](#-faq)
-13. [🤝 Contributing](#-contributing)
-14. [👨‍💻 Community support](#-community-support)
+11. [🌿 Model lifecycle hooks](#model-life-cycle-hooks)
+12. [🧩 Examples](#-examples)
+13. [💬 FAQ](#-faq)
+14. [🤝 Contributing](#-contributing)
+15. [👨‍💻 Community support](#-community-support)
 
 ## ✨ Features
 
@@ -731,6 +732,36 @@ module.exports = {
     };
   },
 };
+```
+
+## Model lifecycle hooks
+
+Navigation plugin allows to register lifecycle hooks for `Navigation` and `NavigationItem` content types.
+
+You can read more about lifecycle hooks [here](https://docs.strapi.io/dev-docs/backend-customization/models#lifecycle-hooks). (You can set a listener for all of the hooks).
+
+Lifecycle hooks can be register either in `register()` or `bootstrap()` methods of your server. You can register more than one listener for a specified lifecycle hook. For example: you want to do three things on navigation item creation and do not want to handle all of these actions in one big function. You can split logic in as many listeners as you want.
+
+Listeners can by sync and `async`.
+
+>Be aware that lifecycle hooks registered in `register()` may be fired by plugin's bootstrapping. If you want listen to events triggered after server's startup use `bootstrap()`.
+
+Example:
+
+```ts
+  const navigationCommonService = strapi
+    .plugin("navigation")
+    .service("common");
+
+  navigationCommonService.registerLifecycleHook({
+    callback: async ({ action, result }) => {
+      const saveResult = await logIntoSystem(action, result);
+
+      console.log(saveResult);
+    },
+    contentTypeName: "navigation-item",
+    hookName: "afterCreate",
+  });
 ```
 
 ## 🧩 Examples

--- a/README.md
+++ b/README.md
@@ -759,6 +759,16 @@ Example:
 
       console.log(saveResult);
     },
+    contentTypeName: "navigation",
+    hookName: "afterCreate",
+  });
+
+  navigationCommonService.registerLifecycleHook({
+    callback: async ({ action, result }) => {
+      const saveResult = await logIntoSystem(action, result);
+
+      console.log(saveResult);
+    },
     contentTypeName: "navigation-item",
     hookName: "afterCreate",
   });

--- a/server/content-types/navigation-item/index.ts
+++ b/server/content-types/navigation-item/index.ts
@@ -1,7 +1,9 @@
 "use strict"
 
+import lifecycles from "./lifecycles";
 import schema from "./schema";
 
 export default {
-  schema
+  schema,
+  lifecycles
 };

--- a/server/content-types/navigation-item/lifecycles.ts
+++ b/server/content-types/navigation-item/lifecycles.ts
@@ -1,0 +1,6 @@
+import { StrapiContext } from "strapi-typed";
+import { buildAllHookListeners } from "../../utils";
+
+export default buildAllHookListeners("navigation-item", {
+  strapi,
+} as unknown as StrapiContext);

--- a/server/content-types/navigation/index.ts
+++ b/server/content-types/navigation/index.ts
@@ -1,7 +1,9 @@
-"use strict"
+"use strict";
 
+import lifecycles from "./lifecycles";
 import schema from "./schema";
 
 export default {
-  schema
+  schema,
+  lifecycles,
 };

--- a/server/content-types/navigation/lifecycles.ts
+++ b/server/content-types/navigation/lifecycles.ts
@@ -1,0 +1,6 @@
+import { StrapiContext } from "strapi-typed";
+import { buildAllHookListeners } from "../../utils";
+
+export default buildAllHookListeners("navigation", {
+  strapi,
+} as unknown as StrapiContext);

--- a/server/controllers/admin.ts
+++ b/server/controllers/admin.ts
@@ -3,10 +3,6 @@ import { errors } from "@strapi/utils"
 import {
   assertIsNumber,
   assertNotEmpty,
-  IAdminService,
-  ICommonService,
-  NavigationService,
-  NavigationServiceName,
   ToBeFixed,
 } from "../../types";
 import { getPluginService, parseParams } from "../utils";
@@ -17,24 +13,25 @@ import { InvalidParamNavigationError } from "../../utils/InvalidParamNavigationE
 import { NavigationError } from "../../utils/NavigationError";
 
 const adminControllers: IAdminController = {
-  getService<T extends NavigationService = IAdminService>(
-    name: NavigationServiceName = "admin"
-  ) {
-    return getPluginService<T>(name);
+  getAdminService() {
+    return getPluginService("admin");
+  },
+  getCommonService() {
+    return getPluginService("common");
   },
   async get() {
-    return await this.getService().get();
+    return await this.getAdminService().get();
   },
   post(ctx) {
     const { auditLog } = ctx;
     const { body = {} } = ctx.request;
-    return this.getService().post(body, auditLog);
+    return this.getAdminService().post(body, auditLog);
   },
   put(ctx) {
     const { params, auditLog } = ctx;
     const { id } = parseParams<StringMap<string>, { id: Id }>(params);
     const { body = {} } = ctx.request;
-    return this.getService().put(id, body, auditLog).catch(errorHandler(ctx));
+    return this.getAdminService().put(id, body, auditLog).catch(errorHandler(ctx));
   },
   async delete(ctx) {
     const { params, auditLog } = ctx;
@@ -43,7 +40,7 @@ const adminControllers: IAdminController = {
     try {
       assertNotEmpty(id, new InvalidParamNavigationError("Navigation's id is not a id"));
 
-      await this.getService().delete(id, auditLog);
+      await this.getAdminService().delete(id, auditLog);
 
       return {};
     } catch (error) {
@@ -57,12 +54,12 @@ const adminControllers: IAdminController = {
     }
   },
   async config() {
-    return this.getService().config();
+    return this.getAdminService().config();
   },
 
   async updateConfig(ctx) {
     try {
-      await this.getService().updateConfig(ctx.request.body);
+      await this.getAdminService().updateConfig(ctx.request.body);
     } catch (e: ToBeFixed) {
       errorHandler(ctx)(e);
     }
@@ -71,7 +68,7 @@ const adminControllers: IAdminController = {
 
   async restoreConfig(ctx) {
     try {
-      await this.getService().restoreConfig();
+      await this.getAdminService().restoreConfig();
     } catch (e: ToBeFixed) {
       errorHandler(ctx)(e);
     }
@@ -79,12 +76,12 @@ const adminControllers: IAdminController = {
   },
 
   async settingsConfig() {
-    return this.getService().config(true);
+    return this.getAdminService().config(true);
   },
 
   async settingsRestart(ctx) {
     try {
-      await this.getService().restart();
+      await this.getAdminService().restart();
       return ctx.send({ status: 200 });
     } catch (e: ToBeFixed) {
       errorHandler(ctx)(e);
@@ -93,12 +90,12 @@ const adminControllers: IAdminController = {
   async getById(ctx) {
     const { params } = ctx;
     const { id } = parseParams<StringMap<string>, { id: Id }>(params);
-    return this.getService().getById(id);
+    return this.getAdminService().getById(id);
   },
   async getContentTypeItems(ctx) {
     const { params, query = {} } = ctx;
     const { model } = parseParams<StringMap<string>, { model: string }>(params);
-    return this.getService<ICommonService>("common").getContentTypeItems(
+    return this.getCommonService().getContentTypeItems(
       model,
       query
     );
@@ -114,7 +111,7 @@ const adminControllers: IAdminController = {
     try {
       assertCopyParams(source, target);
 
-      return this.getService().fillFromOtherLocale({ source, target, auditLog });
+      return this.getAdminService().fillFromOtherLocale({ source, target, auditLog });
     } catch (error) {
       if (error instanceof Error) {
         return ctx.badRequest(error.message)
@@ -137,7 +134,7 @@ const adminControllers: IAdminController = {
         new InvalidParamNavigationError("Path is missing")
       )
 
-      return await this.getService().readNavigationItemFromLocale({
+      return await this.getAdminService().readNavigationItemFromLocale({
         path,
         source,
         target,
@@ -163,7 +160,7 @@ const adminControllers: IAdminController = {
     try {
       assertNotEmpty(q);
 
-      return this.getService<ICommonService>("common").getSlug(q).then((slug) => ({ slug }));
+      return this.getCommonService().getSlug(q).then((slug) => ({ slug }));
     } catch (error) {
       if (error instanceof Error) {
         return ctx.badRequest(error.message)

--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -1,20 +1,12 @@
 //@ts-ignore
 import { errors, sanitize } from "@strapi/utils";
 import { Id, StringMap } from "strapi-typed";
-import {
-  IClientController,
-  IClientService,
-  NavigationService,
-  NavigationServiceName,
-  ToBeFixed,
-} from "../../types";
+import { IClientController, ToBeFixed } from "../../types";
 import { getPluginService, parseParams, sanitizePopulateField } from "../utils";
 
 const clientControllers: IClientController = {
-  getService<T extends NavigationService = IClientService>(
-    name: NavigationServiceName = "client"
-  ) {
-    return getPluginService<T>(name);
+  getService() {
+    return getPluginService("client");
   },
 
   async readAll(ctx) {

--- a/server/graphql/config.ts
+++ b/server/graphql/config.ts
@@ -1,5 +1,4 @@
 import { StrapiContext } from "strapi-typed";
-import { ICommonService } from "../../types";
 import { getPluginService } from "../utils";
 
 const getTypes = require("./types");
@@ -15,7 +14,7 @@ export default async ({ strapi }: StrapiContext) => {
   extensionService
     .shadowCRUD("plugin::navigation.navigations-items-related")
     .disable();
-  const commonService = getPluginService<ICommonService>('common');
+  const commonService = getPluginService('common');
   const pluginStore = await commonService.getPluginStore()
   const config = await pluginStore.get({ key: 'config' });
 

--- a/server/navigation/setupStrategy.ts
+++ b/server/navigation/setupStrategy.ts
@@ -1,5 +1,5 @@
 import { IStrapi, StrapiPlugin } from "strapi-typed";
-import { IAdminService, INavigationSetupStrategy, Navigation } from "../../types";
+import { INavigationSetupStrategy, Navigation } from "../../types";
 import { i18nNavigationSetupStrategy } from "../i18n";
 import { DEFAULT_NAVIGATION_ITEM, DEFAULT_POPULATE, getPluginService } from "../utils";
 
@@ -54,4 +54,4 @@ const createNavigation = ({
   });
 
 const getCurrentNavigations = (): Promise<Navigation[]> =>
-  getPluginService<IAdminService>('admin').get();
+  getPluginService('admin').get();

--- a/server/services/__tests__/service.test.ts
+++ b/server/services/__tests__/service.test.ts
@@ -1,8 +1,8 @@
 import { IStrapi } from "strapi-typed";
-import { IClientService } from "../../../types";
+import { ToBeFixed } from "../../../types";
 
 import setupStrapi from '../../../__mocks__/strapi';
-import { getPluginService, RENDER_TYPES } from "../../utils";
+import { allLifecycleHooks, getPluginService, RENDER_TYPES } from "../../utils";
 
 declare var strapi: IStrapi
 
@@ -36,7 +36,7 @@ describe('Navigation services', () => {
 
   describe('Render navigation', () => {
     it('Can render branch in flat format', async () => {
-      const clientService = getPluginService<IClientService>('client');
+      const clientService = getPluginService('client');
       const result = await clientService.render({ idOrSlug: 1 });
 
       expect(result).toBeDefined()
@@ -47,7 +47,7 @@ describe('Navigation services', () => {
     });
 
     it('Can render branch in flat format for GraphQL', async () => {
-      const clientService = getPluginService<IClientService>('client');
+      const clientService = getPluginService('client');
       const result = await clientService.render({ idOrSlug: 1, wrapRelated: true });
 
       expect(result).toBeDefined();
@@ -58,7 +58,7 @@ describe('Navigation services', () => {
     });
 
     it('Can render branch in tree format', async () => {
-      const clientService = getPluginService<IClientService>('client');
+      const clientService = getPluginService('client');
       const result = await clientService.render({
         idOrSlug: 1,
         type: RENDER_TYPES.TREE
@@ -72,7 +72,7 @@ describe('Navigation services', () => {
     });
 
     it('Can render branch in tree format for GraphQL', async () => {
-      const clientService = getPluginService<IClientService>('client');
+      const clientService = getPluginService('client');
       const result = await clientService.render({
         idOrSlug: 1,
         type: RENDER_TYPES.TREE,
@@ -89,7 +89,7 @@ describe('Navigation services', () => {
     });
 
     it('Can render branch in rfr format', async () => {
-      const clientService = getPluginService<IClientService>('client');
+      const clientService = getPluginService('client');
       const result = await clientService.render({
         idOrSlug: 1,
         type: RENDER_TYPES.RFR
@@ -101,7 +101,7 @@ describe('Navigation services', () => {
     });
 
     it('Can render branch in rfr format for GraphQL', async () => {
-      const clientService = getPluginService<IClientService>('client');
+      const clientService = getPluginService('client');
       const result = await clientService.render({
         idOrSlug: 1,
         type: RENDER_TYPES.RFR,
@@ -115,7 +115,7 @@ describe('Navigation services', () => {
     });
 
     it('Can render only menu attached elements', async () => {
-      const clientService = getPluginService<IClientService>('client');
+      const clientService = getPluginService('client');
       const result = await clientService.render({
         idOrSlug: 1,
         type: RENDER_TYPES.FLAT,
@@ -127,7 +127,7 @@ describe('Navigation services', () => {
     });
 
     it('Can render branch by path', async () => {
-      const clientService = getPluginService<IClientService>('client');
+      const clientService = getPluginService('client');
       const result = await clientService.render({
         idOrSlug: 1,
         type: RENDER_TYPES.FLAT,
@@ -142,11 +142,43 @@ describe('Navigation services', () => {
 
   describe('Render child', () => {
     it('Can render child', async () => {
-      const clientService = getPluginService<IClientService>('client');
+      const clientService = getPluginService('client');
       const result = await clientService.renderChildren({idOrSlug: 1, childUIKey: "home"});
 
       expect(result).toBeDefined();
       expect(result.length).toBe(1);
     });
   });
+
+  describe('Lifecycle hooks', () => {
+    it.each(allLifecycleHooks)('should trigger for %s hook listener', async (hookName: ToBeFixed) => {
+      // Given
+      const commonService = getPluginService('common');
+      const listenerA = jest.fn().mockResolvedValue("ABC");
+      const listenerB = jest.fn();
+      const event = {} as ToBeFixed
+      
+      commonService.registerLifecycleHook({
+        callback: listenerA,
+        contentTypeName: "navigation",
+        hookName,
+      })
+      commonService.registerLifecycleHook({
+        callback: listenerB,
+        contentTypeName: "navigation",
+        hookName,
+      })
+
+      // When
+      await commonService.runLifecycleHook({
+        contentTypeName: "navigation",
+        event,
+        hookName,
+      })
+
+      // Then
+      expect(listenerA).toHaveBeenCalledTimes(1);
+      expect(listenerB).toHaveBeenCalledTimes(1);
+    })
+  })
 });

--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -6,7 +6,6 @@ import {
   Audience,
   AuditLogContext,
   IAdminService,
-  ICommonService,
   Navigation,
   NavigationItem,
   NavigationItemCustomField,
@@ -42,7 +41,7 @@ const adminService: (context: StrapiContext) => IAdminService = ({
   strapi,
 }) => ({
   async config(viaSettingsPage = false): Promise<SettingsPageConfig> {
-    const commonService = getPluginService<ICommonService>("common");
+    const commonService = getPluginService("common");
     const { audienceModel } = getPluginModels();
     const pluginStore = await commonService.getPluginStore();
     const config = await pluginStore.get<string, NavigationPluginConfig>({
@@ -127,7 +126,7 @@ const adminService: (context: StrapiContext) => IAdminService = ({
   },
 
   async getById(id: Id): Promise<Navigation> {
-    const commonService = getPluginService<ICommonService>("common");
+    const commonService = getPluginService("common");
 
     const { masterModel, itemModel } = getPluginModels();
     const entity = await strapi
@@ -152,8 +151,8 @@ const adminService: (context: StrapiContext) => IAdminService = ({
   },
 
   async post(payload: ToBeFixed, auditLog: AuditLogContext) {
-    const commonService = getPluginService<ICommonService>("common");
-    const adminService = getPluginService<IAdminService>("admin");
+    const commonService = getPluginService("common");
+    const adminService = getPluginService("admin");
     const { enabled: i18nEnabled, defaultLocale } = await getI18nStatus({
       strapi,
     });
@@ -200,8 +199,8 @@ const adminService: (context: StrapiContext) => IAdminService = ({
     payload: Navigation & { items: ToBeFixed },
     auditLog: AuditLogContext
   ) {
-    const adminService = getPluginService<IAdminService>("admin");
-    const commonService = getPluginService<ICommonService>("common");
+    const adminService = getPluginService("admin");
+    const commonService = getPluginService("common");
     const { enabled: i18nEnabled } = await getI18nStatus({ strapi });
 
     const { masterModel } = getPluginModels();
@@ -275,7 +274,7 @@ const adminService: (context: StrapiContext) => IAdminService = ({
 
   async delete(id, auditLog) {
     const { masterModel, itemModel } = getPluginModels();
-    const adminService = getPluginService<IAdminService>("admin");
+    const adminService = getPluginService("admin");
     const entity = await adminService.getById(id);
     const { enabled: i18nEnabled } = await getI18nStatus({ strapi });
     // TODO: remove when cascade deletion is present
@@ -324,14 +323,14 @@ const adminService: (context: StrapiContext) => IAdminService = ({
   },
 
   async restoreConfig(): Promise<void> {
-    const commonService = getPluginService<ICommonService>("common");
+    const commonService = getPluginService("common");
     const pluginStore = await commonService.getPluginStore();
     await pluginStore.delete({ key: "config" });
     await commonService.setDefaultConfig();
   },
 
   async updateConfig(newConfig: NavigationPluginConfig): Promise<void> {
-    const commonService = getPluginService<ICommonService>("common");
+    const commonService = getPluginService("common");
     const pluginStore = await commonService.getPluginStore();
     const config = await pluginStore.get<string, NavigationPluginConfig>({
       key: "config",
@@ -356,8 +355,8 @@ const adminService: (context: StrapiContext) => IAdminService = ({
       throw new NavigationError("Not yet implemented.");
     }
 
-    const adminService = getPluginService<IAdminService>("admin");
-    const commonService = getPluginService<ICommonService>("common");
+    const adminService = getPluginService("admin");
+    const commonService = getPluginService("common");
     const targetEntity = await adminService.getById(target);
 
     return await i18nNavigationContentsCopy({

--- a/server/services/client.ts
+++ b/server/services/client.ts
@@ -1,7 +1,7 @@
 import { first, get, isEmpty, isNil, isString, isArray, last, toNumber } from "lodash";
 import { Id, StrapiContext } from "strapi-typed";
 import { validate } from "uuid";
-import { assertNotEmpty, ContentTypeEntity, IAdminService, IClientService, ICommonService, Navigation, NavigationItem, NavigationItemEntity, RFRNavItem, ToBeFixed } from "../../types"
+import { assertNotEmpty, ContentTypeEntity, IClientService, Navigation, NavigationItem, NavigationItemEntity, RFRNavItem, ToBeFixed } from "../../types"
 import { composeItemTitle, getPluginModels, filterByPath, filterOutUnpublished, getPluginService, templateNameFactory, RENDER_TYPES, compareArraysOfNumbers, getCustomFields } from "../utils";
 //@ts-ignore
 import { errors } from '@strapi/utils';
@@ -37,7 +37,7 @@ const clientService: (context: StrapiContext) => IClientService = ({ strapi }) =
     locale,
     populate,
   }) {
-    const clientService = getPluginService<IClientService>('client');
+    const clientService = getPluginService('client');
 
     const findById = !isNaN(toNumber(idOrSlug)) || validate(idOrSlug as string);
     const criteria = findById ? { id: idOrSlug } : { slug: idOrSlug };
@@ -55,7 +55,7 @@ const clientService: (context: StrapiContext) => IClientService = ({ strapi }) =
     wrapRelated = false,
     locale,
   }) {
-    const clientService = getPluginService<IClientService>('client');
+    const clientService = getPluginService('client');
     const findById = !isNaN(toNumber(idOrSlug)) || validate(idOrSlug as string);
     const criteria = findById ? { id: idOrSlug } : { slug: idOrSlug };
     const filter = type === RENDER_TYPES.FLAT ? null : childUIKey;
@@ -75,7 +75,7 @@ const clientService: (context: StrapiContext) => IClientService = ({ strapi }) =
     contentTypes = [],
     enabledCustomFieldsNames,
   }) {
-    const clientService = getPluginService<IClientService>('client');
+    const clientService = getPluginService('client');
     let pages = {};
     let nav = {};
     let navItems: RFRNavItem[] = [];
@@ -260,9 +260,9 @@ const clientService: (context: StrapiContext) => IClientService = ({ strapi }) =
     locale,
     populate,
   }) {
-    const clientService = getPluginService<IClientService>('client');
-    const adminService = getPluginService<IAdminService>('admin');
-    const commonService = getPluginService<ICommonService>('common');
+    const clientService = getPluginService('client');
+    const adminService = getPluginService('admin');
+    const commonService = getPluginService('common');
     const entityWhereClause = {
       ...criteria,
       visible: true,

--- a/server/utils/constant.ts
+++ b/server/utils/constant.ts
@@ -1,4 +1,4 @@
-import { RenderTypeOptions } from "../../types";
+import { LifeCycleHookName, RenderTypeOptions } from "../../types";
 import { I18N_DEFAULT_POPULATE } from "../i18n";
 
 export const TEMPLATE_DEFAULT = 'Generic' as const;
@@ -19,3 +19,27 @@ export const RENDER_TYPES = {
   TREE: 'TREE',
   RFR: 'RFR'
 } as RenderTypeOptions;
+
+
+export type ContentType = "navigation" | "navigation-item";
+
+export const allLifecycleHooks: ReadonlyArray<LifeCycleHookName> = [
+  "beforeCreate",
+  "beforeCreateMany",
+  "afterCreate",
+  "afterCreateMany",
+  "beforeUpdate",
+  "beforeUpdateMany",
+  "afterUpdate",
+  "afterUpdateMany",
+  "beforeDelete",
+  "beforeDeleteMany",
+  "afterDelete",
+  "afterDeleteMany",
+  "beforeCount",
+  "afterCount",
+  "beforeFindOne",
+  "afterFindOne",
+  "beforeFindMany",
+  "afterFindMany",
+] as const;

--- a/server/utils/functions.ts
+++ b/server/utils/functions.ts
@@ -33,7 +33,6 @@ import {
   NavigationItemAdditionalField,
   NavigationItemCustomField,
   NavigationItemEntity,
-  NavigationService,
   NavigationServiceName,
   NestedPath,
   NestedStructure,
@@ -54,11 +53,16 @@ type Populate =
 
 const UID_REGEX = /^(?<type>[a-z0-9-]+)\:{2}(?<api>[a-z0-9-]+)\.{1}(?<contentType>[a-z0-9-]+)$/i;
 
-export function getPluginService(name: "client"): IClientService;
-export function getPluginService(name: "admin"): IAdminService;
-export function getPluginService(name: "common"): ICommonService;
-export function getPluginService(name: NavigationServiceName) {
-  return strapi.plugin("navigation").service(name) as NavigationService
+type TypeMap = {
+  client: IClientService,
+  admin: IAdminService,
+  common: ICommonService
+}
+
+export function getPluginService<T extends NavigationServiceName>(name: T): T extends infer R extends NavigationServiceName 
+  ? TypeMap[R] 
+  : never {
+  return strapi.plugin("navigation").service(name)
 }
 
 export const errorHandler = (ctx: ToBeFixed) => (error: NavigationError | string) => {

--- a/server/utils/functions.ts
+++ b/server/utils/functions.ts
@@ -14,7 +14,7 @@ import {
   uniqBy,
   zipWith,
 } from 'lodash';
-import { PopulateClause } from 'strapi-typed';
+import { PopulateClause, StrapiContext } from 'strapi-typed';
 import { Id, IStrapi, Primitive, StrapiContentType, StringMap, StrapiContentTypeFullSchema } from "strapi-typed";
 
 import {
@@ -22,6 +22,12 @@ import {
   AuditLogContext,
   AuditLogParams,
   ContentTypeEntity,
+  Effect,
+  IAdminService,
+  IClientService,
+  ICommonService,
+  LifeCycleEvent,
+  LifeCycleHookName,
   NavigationActions,
   NavigationItem,
   NavigationItemAdditionalField,
@@ -36,7 +42,7 @@ import {
   ToBeFixed,
 } from "../../types";
 import { NavigationError } from '../../utils/NavigationError';
-import { TEMPLATE_DEFAULT, ALLOWED_CONTENT_TYPES, RESTRICTED_CONTENT_TYPES } from './constant';
+import { TEMPLATE_DEFAULT, ALLOWED_CONTENT_TYPES, RESTRICTED_CONTENT_TYPES, ContentType, allLifecycleHooks } from './constant';
 declare var strapi: IStrapi;
 
 type Populate =
@@ -48,8 +54,12 @@ type Populate =
 
 const UID_REGEX = /^(?<type>[a-z0-9-]+)\:{2}(?<api>[a-z0-9-]+)\.{1}(?<contentType>[a-z0-9-]+)$/i;
 
-export const getPluginService = <T extends NavigationService>(name: NavigationServiceName): T =>
-  strapi.plugin("navigation").service(name);
+export function getPluginService(name: "client"): IClientService;
+export function getPluginService(name: "admin"): IAdminService;
+export function getPluginService(name: "common"): ICommonService;
+export function getPluginService(name: NavigationServiceName) {
+  return strapi.plugin("navigation").service(name) as NavigationService
+}
 
 export const errorHandler = (ctx: ToBeFixed) => (error: NavigationError | string) => {
   if (error instanceof NavigationError) {
@@ -442,3 +452,29 @@ export const sanitizePopulateField = (populate: Populate): Populate => {
 
   return populate;
 };
+
+export const buildHookListener =
+  (contentTypeName: ContentType, { strapi }: StrapiContext) =>
+  (hookName: LifeCycleHookName): [LifeCycleHookName, Effect<LifeCycleEvent>] =>
+    [
+      hookName,
+      async (event) => {
+        const commonService: ICommonService = strapi
+          .plugin("navigation")
+          .service("common");
+
+        await commonService.runLifecycleHook({
+          contentTypeName,
+          hookName,
+          event,
+        });
+      },
+    ];
+
+export const buildAllHookListeners = (
+  contentTypeName: ContentType,
+  context: StrapiContext,
+): Record<LifeCycleHookName, Effect<LifeCycleEvent>> =>
+  Object.fromEntries(
+    allLifecycleHooks.map(buildHookListener(contentTypeName, context))
+  ) as ToBeFixed;

--- a/types/controllers.ts
+++ b/types/controllers.ts
@@ -1,6 +1,6 @@
 import { StrapiController } from "strapi-typed";
 import { Navigation, NotVoid } from "./contentTypes";
-import { IAdminService, IClientService, NavigationService, NavigationServiceName } from "./services";
+import { IAdminService, IClientService, ICommonService } from "./services";
 import { AuditLogContext, StrapiControllerContext, ToBeFixed } from "./utils";
 
 type ControllerCommonContext = {
@@ -8,8 +8,8 @@ type ControllerCommonContext = {
 };
 
 export interface IAdminController {
-  getService: <T extends NavigationService = IAdminService>(name?: NavigationServiceName) => T;
-
+  getAdminService(): IAdminService;
+  getCommonService(): ICommonService;
   config: () => ToBeFixed;
   get: StrapiController<Promise<Array<Navigation>>>;
   getById: StrapiController<Promise<Navigation>, never, never, { id: string }>;
@@ -31,7 +31,7 @@ export interface IAdminController {
 };
 
 export interface IClientController {
-  getService: <T extends NavigationService = IClientService>(name?: NavigationServiceName) => T;
+  getService: () => IClientService;
 
   render: (ctx: StrapiControllerContext) => ToBeFixed;
   renderChild: (ctx: StrapiControllerContext) => ToBeFixed;

--- a/types/index.ts
+++ b/types/index.ts
@@ -6,3 +6,4 @@ export * from './services';
 export * from './utils';
 export * from './bootstrap';
 export * from './graphQL';
+export * from './lifecycle';

--- a/types/lifecycle.ts
+++ b/types/lifecycle.ts
@@ -1,0 +1,45 @@
+import { Effect } from "./utils";
+
+export type LifeCycleHookName =
+  | "beforeCreate"
+  | "beforeCreateMany"
+  | "afterCreate"
+  | "afterCreateMany"
+  | "beforeUpdate"
+  | "beforeUpdateMany"
+  | "afterUpdate"
+  | "afterUpdateMany"
+  | "beforeDelete"
+  | "beforeDeleteMany"
+  | "afterDelete"
+  | "afterDeleteMany"
+  | "beforeCount"
+  | "afterCount"
+  | "beforeFindOne"
+  | "afterFindOne"
+  | "beforeFindMany"
+  | "afterFindMany";
+
+export interface LifeCycleEvent<
+  THookName extends LifeCycleHookName = LifeCycleHookName,
+  TResult = unknown,
+  TParams = Record<string, unknown>
+> {
+  action: THookName;
+  model: {
+    singularName: string;
+    uid: string;
+    tableName: string;
+    attributes: Record<string, unknown>;
+    lifecycles: Partial<Record<LifeCycleHookName, Effect<LifeCycleEvent>>>;
+    indexes: Array<{
+      type?: string;
+      name: string;
+      columns: string[];
+    }>;
+    columnToAttribute: Record<string, string>;
+  };
+  state: Record<string, unknown>;
+  params: TParams;
+  result?: TResult | TResult[];
+}

--- a/types/services.ts
+++ b/types/services.ts
@@ -2,7 +2,9 @@ import { Id, StrapiContentType, StrapiEvents, StrapiStore, StringMap } from "str
 import { NavigationPluginConfig } from "./config";
 import { Navigation, NavigationItem, NavigationItemCustomField, NavigationItemEntity, NavigationItemInput, NestedStructure, NotVoid, RelatedRef, RelatedRefBase } from "./contentTypes";
 import { I18nQueryParams } from "./i18n";
-import { AuditLogContext, ContentTypeEntity, NavigationActions, NavigationActionsPerItem, PopulateQueryParam, RenderType, RFRNavItem, ToBeFixed } from "./utils";
+import { AuditLogContext, ContentTypeEntity, Effect, NavigationActions, NavigationActionsPerItem, PopulateQueryParam, RenderType, RFRNavItem, ToBeFixed } from "./utils";
+import { ContentType } from "../server/utils";
+import { LifeCycleEvent, LifeCycleHookName } from "./lifecycle";
 
 export type NavigationServiceName = "common" | "admin" | "client"
 export type NavigationService = ICommonService | IAdminService | IClientService
@@ -41,6 +43,8 @@ export interface ICommonService {
   setDefaultConfig: () => Promise<NavigationPluginConfig>,
   updateBranch: (toUpdate: NestedStructure<NavigationItem>[], masterEntity: Navigation | null, parentItem: NavigationItemEntity | null, operations: NavigationActions) => ToBeFixed,
   getSlug(query: string): Promise<string>;
+  registerLifecycleHook(input: { hookName: LifeCycleHookName, callback: Effect<LifeCycleEvent>, contentTypeName: ContentType }): void;
+  runLifecycleHook(input: { hookName: LifeCycleHookName, event: LifeCycleEvent, contentTypeName: ContentType }): Promise<void>;
 }
 
 export interface IClientService {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/332

## Summary

- registering lifecycle hooks for navigation and navigation item
- typing refactor for `getPluginService()` function (upfront type specification not longer required)

## Test Plan

- run `npm run test:unit`
- specify lifecycle hook(s) as specified in Readme file
- start the server
- validate hooks being run against your configuration