### PR TITLE
fix: menu items deletion on menu delete

### DIFF
--- a/server/services/__tests__/service.test.ts
+++ b/server/services/__tests__/service.test.ts
@@ -1,10 +1,10 @@
 import { IStrapi, StrapiContext, StrapiStore } from "strapi-typed";
-import { ICommonService, Navigation, ToBeFixed } from "../../../types";
+import { ICommonService, Navigation, NavigationItem, ToBeFixed } from "../../../types";
 
 import setupStrapi from "../../../__mocks__/strapi";
 import { allLifecycleHooks, getPluginService, RENDER_TYPES } from "../../utils";
-import clientService from "../client";
 import adminService from "../admin";
+import clientService from "../client";
 
 declare var strapi: IStrapi;
 
@@ -534,6 +534,7 @@ describe("Navigation services", () => {
 
   describe("AdminService", () => {
     let navigationIndex = 0;
+    let itemIndex = 0;
     const generateNavigation = (
       rest: Partial<Navigation> = {}
     ): Partial<Navigation> => ({
@@ -544,6 +545,13 @@ describe("Navigation services", () => {
 
     beforeEach(() => {
       navigationIndex = 0;
+    });
+    const generateNavigationItem = (
+      rest: Partial<NavigationItem> = {}
+    ): Partial<NavigationItem> => ({
+      path: `/navigation-item-${++itemIndex}`,
+      id: ++itemIndex,
+      ...rest,
     });
 
     describe("get()", () => {
@@ -996,6 +1004,325 @@ describe("Navigation services", () => {
               ],
               "name": "Navigation-23",
             },
+          ]
+        `);
+      });
+    });
+
+    describe("delete()", () => {
+      it("should delete navigation with items", async () => {
+        // Given
+        const auditLogMock = jest.fn();
+        const ids = [1];
+        const navigations = ids.map((id) => generateNavigation({ id }));
+        const locale = "en";
+        const activeLocale = [locale];
+        const findManyNavigation = jest.fn();
+        const findManyNavigationItem = jest.fn();
+        const deleteNavigation = jest.fn();
+        const deleteManyNavigation = jest.fn();
+        const deleteManyNavigationItem = jest.fn();
+        const query = (uid: string): any => {
+          if (uid === "plugin::navigation.navigation") {
+            return {
+              findMany: findManyNavigation,
+              delete: deleteNavigation,
+              deleteMany: deleteManyNavigation,
+            };
+          }
+
+          return {
+            findMany: findManyNavigationItem,
+            deleteMany: deleteManyNavigationItem,
+          };
+        };
+        const i18nPluginService = {
+          getDefaultLocale() {
+            return locale;
+          },
+          find() {
+            return activeLocale.map((code) => ({ code }));
+          },
+        } as ToBeFixed;
+        const i18nPlugin = {
+          service() {
+            return i18nPluginService;
+          },
+        };
+        const store = () =>
+          ({
+            get() {
+              return { i18nEnabled: false };
+            },
+          } as ToBeFixed);
+        const strapi: Partial<StrapiContext["strapi"]> = {
+          query,
+          plugin(name): any {
+            return name === "i18n" ? i18nPlugin : null;
+          },
+          store,
+        };
+        const adminServiceBuilt = adminService({ strapi } as StrapiContext);
+
+        findManyNavigation.mockResolvedValue(navigations);
+        findManyNavigationItem.mockResolvedValueOnce([
+          generateNavigationItem({}),
+          generateNavigationItem({}),
+        ]);
+
+        adminServiceBuilt.getById = jest.fn();
+
+        (adminServiceBuilt.getById as jest.Mock).mockReturnValue(
+          navigations[0]
+        );
+
+        // When
+        await adminServiceBuilt.delete(1, { emit: auditLogMock });
+
+        // Then
+        expect(findManyNavigation.mock.calls).toMatchInlineSnapshot(`Array []`);
+        expect(findManyNavigationItem.mock.calls).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              Object {
+                "limit": 9007199254740991,
+                "where": Object {
+                  "$or": Array [
+                    Object {
+                      "master": 1,
+                    },
+                  ],
+                },
+              },
+            ],
+          ]
+        `);
+        expect(deleteManyNavigation.mock.calls).toMatchInlineSnapshot(
+          `Array []`
+        );
+        expect(deleteManyNavigationItem.mock.calls).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              Object {
+                "where": Object {
+                  "id": Array [
+                    2,
+                    4,
+                  ],
+                },
+              },
+            ],
+          ]
+        `);
+        expect(deleteNavigation.mock.calls).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              Object {
+                "where": Object {
+                  "id": 1,
+                },
+              },
+            ],
+          ]
+        `);
+        expect(auditLogMock.mock.calls).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              "onNavigationDeletion",
+              Object {
+                "actionType": "DELETE",
+                "entity": Object {
+                  "id": 1,
+                  "name": "Navigation-61",
+                },
+              },
+            ],
+          ]
+        `);
+      });
+
+      it("should delete navigation with localisations", async () => {
+        // Given
+        const auditLogMock = jest.fn();
+        const allLocale = ["en", "pl"];
+        const activeLocale = allLocale.filter((locale) => locale != "fr");
+        const locale = allLocale[0];
+        const navigations = allLocale.map((localeCode) =>
+          generateNavigation({
+            localeCode,
+            localizations: allLocale
+              .filter((locale) => locale !== localeCode)
+              .map((_localeCode) =>
+                generateNavigation({ localeCode: _localeCode })
+              ) as ToBeFixed,
+          })
+        );
+        const findManyNavigation = jest.fn();
+        const findManyNavigationItem = jest.fn();
+        const deleteNavigation = jest.fn();
+        const deleteManyNavigation = jest.fn();
+        const deleteManyNavigationItem = jest.fn();
+        const query = (uid: string): any => {
+          if (uid === "plugin::navigation.navigation") {
+            return {
+              findMany: findManyNavigation,
+              delete: deleteNavigation,
+              deleteMany: deleteManyNavigation,
+            };
+          }
+
+          return {
+            findMany: findManyNavigationItem,
+            deleteMany: deleteManyNavigationItem,
+          };
+        };
+        const i18nPluginService = {
+          getDefaultLocale() {
+            return locale;
+          },
+          find() {
+            return activeLocale.map((code) => ({ code }));
+          },
+        } as ToBeFixed;
+        const i18nPlugin = {
+          service() {
+            return i18nPluginService;
+          },
+        };
+        const store = () =>
+          ({
+            get() {
+              return { i18nEnabled: true };
+            },
+          } as ToBeFixed);
+        const strapi: Partial<StrapiContext["strapi"]> = {
+          query,
+          plugin(name): any {
+            return name === "i18n" ? i18nPlugin : null;
+          },
+          store,
+        };
+        const adminServiceBuilt = adminService({ strapi } as StrapiContext);
+        const id = navigations[0].id;
+
+        findManyNavigation.mockResolvedValue(navigations);
+
+        [1, 2, 3, 4, 5].forEach(() => {
+          findManyNavigationItem.mockResolvedValueOnce([
+            generateNavigationItem({}),
+            generateNavigationItem({}),
+          ]);
+        });
+
+        adminServiceBuilt.getById = jest.fn();
+
+        (adminServiceBuilt.getById as jest.Mock).mockReturnValue(
+          navigations[0]
+        );
+
+        // When
+        await adminServiceBuilt.delete(id!, { emit: auditLogMock });
+
+        // Then
+        expect(findManyNavigation.mock.calls).toMatchInlineSnapshot(`Array []`);
+        expect(findManyNavigationItem.mock.calls).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              Object {
+                "limit": 9007199254740991,
+                "where": Object {
+                  "$or": Array [
+                    Object {
+                      "master": 66,
+                    },
+                  ],
+                },
+              },
+            ],
+            Array [
+              Object {
+                "limit": 9007199254740991,
+                "where": Object {
+                  "$or": Array [
+                    Object {
+                      "master": 64,
+                    },
+                  ],
+                },
+              },
+            ],
+          ]
+        `);
+        expect(deleteManyNavigation.mock.calls).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              Object {
+                "where": Object {
+                  "id": Object {
+                    "$in": Array [
+                      64,
+                    ],
+                  },
+                },
+              },
+            ],
+          ]
+        `);
+        expect(deleteManyNavigationItem.mock.calls).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              Object {
+                "where": Object {
+                  "id": Array [
+                    6,
+                    8,
+                  ],
+                },
+              },
+            ],
+            Array [
+              Object {
+                "where": Object {
+                  "id": Array [
+                    10,
+                    12,
+                  ],
+                },
+              },
+            ],
+          ]
+        `);
+        expect(deleteNavigation.mock.calls).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              Object {
+                "where": Object {
+                  "id": 66,
+                },
+              },
+            ],
+          ]
+        `);
+        expect(auditLogMock.mock.calls).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              "onNavigationDeletion",
+              Object {
+                "actionType": "DELETE",
+                "entity": Object {
+                  "id": 66,
+                  "localeCode": "en",
+                  "localizations": Array [
+                    Object {
+                      "id": 64,
+                      "localeCode": "pl",
+                      "name": "Navigation-63",
+                    },
+                  ],
+                  "name": "Navigation-65",
+                },
+              },
+            ],
           ]
         `);
       });

--- a/server/services/__tests__/service.test.ts
+++ b/server/services/__tests__/service.test.ts
@@ -1,5 +1,10 @@
 import { IStrapi, StrapiContext, StrapiStore } from "strapi-typed";
-import { ICommonService, Navigation, NavigationItem, ToBeFixed } from "../../../types";
+import {
+  ICommonService,
+  Navigation,
+  NavigationItem,
+  ToBeFixed,
+} from "../../../types";
 
 import setupStrapi from "../../../__mocks__/strapi";
 import { allLifecycleHooks, getPluginService, RENDER_TYPES } from "../../utils";
@@ -1133,7 +1138,7 @@ describe("Navigation services", () => {
                 "actionType": "DELETE",
                 "entity": Object {
                   "id": 1,
-                  "name": "Navigation-61",
+                  "name": "Navigation-1",
                 },
               },
             ],
@@ -1233,7 +1238,7 @@ describe("Navigation services", () => {
                 "where": Object {
                   "$or": Array [
                     Object {
-                      "master": 66,
+                      "master": 4,
                     },
                   ],
                 },
@@ -1245,7 +1250,7 @@ describe("Navigation services", () => {
                 "where": Object {
                   "$or": Array [
                     Object {
-                      "master": 64,
+                      "master": 2,
                     },
                   ],
                 },
@@ -1260,7 +1265,7 @@ describe("Navigation services", () => {
                 "where": Object {
                   "id": Object {
                     "$in": Array [
-                      64,
+                      2,
                     ],
                   },
                 },
@@ -1297,7 +1302,7 @@ describe("Navigation services", () => {
             Array [
               Object {
                 "where": Object {
-                  "id": 66,
+                  "id": 4,
                 },
               },
             ],
@@ -1310,16 +1315,16 @@ describe("Navigation services", () => {
               Object {
                 "actionType": "DELETE",
                 "entity": Object {
-                  "id": 66,
+                  "id": 4,
                   "localeCode": "en",
                   "localizations": Array [
                     Object {
-                      "id": 64,
+                      "id": 2,
                       "localeCode": "pl",
-                      "name": "Navigation-63",
+                      "name": "Navigation-1",
                     },
                   ],
-                  "name": "Navigation-65",
+                  "name": "Navigation-3",
                 },
               },
             ],
@@ -1526,7 +1531,7 @@ describe("Navigation services", () => {
         `);
       });
     });
-    
+
     describe("restoreConfig()", () => {
       it("should restore config", async () => {
         // Given
@@ -1556,7 +1561,6 @@ describe("Navigation services", () => {
         // Then
         expect(pluginStore.delete).toHaveBeenCalled();
         expect(commonService.setDefaultConfig).toHaveBeenCalled();
-
       });
     });
   });

--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -300,6 +300,10 @@ const adminService: (context: StrapiContext) => IAdminService = ({
     // TODO: remove when cascade deletion is present
     // NOTE: Delete many with relation `where` crashes ORM
     const cleanNavigationItems = async (masterIds: Array<Id>) => {
+      if (masterIds.length < 1) {
+        return;
+      }
+
       const navigationItems = await strapi.query<NavigationItem>(itemModel.uid).findMany({
         where: {
           $or: masterIds.map((id) => ({ master: id }))
@@ -309,7 +313,7 @@ const adminService: (context: StrapiContext) => IAdminService = ({
 
       await strapi.query<NavigationItem>(itemModel.uid).deleteMany({
         where: {
-          $or: navigationItems.map(({ id }) => ({ id }))
+          id:  navigationItems.map(({ id }) => ( id )),
         },
       });
     };

--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -306,14 +306,14 @@ const adminService: (context: StrapiContext) => IAdminService = ({
 
       const navigationItems = await strapi.query<NavigationItem>(itemModel.uid).findMany({
         where: {
-          $or: masterIds.map((id) => ({ master: id }))
+          $or: masterIds.map((id) => ({ master: id })),
         },
         limit: Number.MAX_SAFE_INTEGER,
       });
 
       await strapi.query<NavigationItem>(itemModel.uid).deleteMany({
         where: {
-          id:  navigationItems.map(({ id }) => ( id )),
+          id: navigationItems.map(({ id }) => (id)),
         },
       });
     };

--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -294,8 +294,7 @@ const adminService: (context: StrapiContext) => IAdminService = ({
 
   async delete(id, auditLog) {
     const { masterModel, itemModel } = getPluginModels();
-    const adminService = getPluginService("admin");
-    const entity = await adminService.getById(id);
+    const entity = await this.getById(id);
     const { enabled: i18nEnabled } = await getI18nStatus({ strapi });
     // TODO: remove when cascade deletion is present
     // NOTE: Delete many with relation `where` crashes ORM


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/424

## Summary

What does this PR do/solve? 

- deleting all navigation items on a navigation delete

context: If a navigation has no items `$or` using an empty list results in all table rows to be included.

## Test Plan

- start strapi server
- delete a navigation
- only related navigation items should be deleted