### PR TITLE
feat: item auto-synce persistence

### DIFF
--- a/admin/src/pages/View/components/NavigationItemForm/index.tsx
+++ b/admin/src/pages/View/components/NavigationItemForm/index.tsx
@@ -1,30 +1,29 @@
-import React, { useEffect, useMemo, useState, useCallback } from 'react';
-import { find, get, first, isEmpty, isEqual, isNil, isString, isObject, sortBy } from 'lodash';
+import { FormikProps, useFormik } from 'formik';
+import { find, first, get, isEmpty, isEqual, isNil, isObject, isString, sortBy } from 'lodash';
 import { prop } from 'lodash/fp';
-import { useFormik, FormikProps } from 'formik';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 //@ts-ignore
 import { ModalBody } from '@strapi/design-system/ModalLayout';
 //@ts-ignore
-import { Select, Option } from '@strapi/design-system/Select';
+import { Option, Select } from '@strapi/design-system/Select';
 //@ts-ignore
 import { Grid, GridItem } from '@strapi/design-system/Grid';
 import { GenericInput } from '@strapi/helper-plugin';
 //@ts-ignore
 import { Button } from '@strapi/design-system/Button';
 
-import { NavigationItemPopupFooter } from '../NavigationItemPopup/NavigationItemPopupFooter';
-import { getDefaultCustomFields, navigationItemType } from '../../../../utils';
-import { extractRelatedItemLabel } from '../../utils/parsers';
-import * as formDefinition from './utils/form';
-import { checkFormValidity } from '../../utils/form';
-import { getTrad, getTradId } from '../../../../translations';
-import { assertString, Audience, Effect, NavigationItemAdditionalField, NavigationItemType, ToBeFixed } from '../../../../../../types';
-import { ContentTypeSearchQuery, NavigationItemFormData, NavigationItemFormProps, RawFormPayload, SanitizedFormPayload, Slugify } from './types';
-import AdditionalFieldInput from '../../../../components/AdditionalFieldInput';
-import { getMessage, ResourceState } from '../../../../utils';
 import { Id } from 'strapi-typed';
+import { Audience, Effect, NavigationItemAdditionalField, NavigationItemType, ToBeFixed, assertString } from '../../../../../../types';
+import AdditionalFieldInput from '../../../../components/AdditionalFieldInput';
+import { getTrad, getTradId } from '../../../../translations';
+import { ResourceState, getDefaultCustomFields, getMessage, navigationItemType } from '../../../../utils';
+import { checkFormValidity } from '../../utils/form';
+import { extractRelatedItemLabel } from '../../utils/parsers';
 import { GenericInputOnChangeInput } from '../../utils/types';
+import { NavigationItemPopupFooter } from '../NavigationItemPopup/NavigationItemPopupFooter';
+import { ContentTypeSearchQuery, NavigationItemFormData, NavigationItemFormProps, RawFormPayload, SanitizedFormPayload, Slugify } from './types';
+import * as formDefinition from './utils/form';
 
 const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
   config,
@@ -50,7 +49,6 @@ const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
 }) => {
   const [isLoading, setIsLoading] = useState(isPreloading);
   const [hasBeenInitialized, setInitializedState] = useState(false);
-  const [autoSync, setAutoSync] = useState(true);
   const [hasChanged, setChangedState] = useState(false);
   const [contentTypeSearchQuery, setContentTypeSearchQuery] = useState<ContentTypeSearchQuery>(undefined);
   const { canUpdate } = permissions;
@@ -94,6 +92,7 @@ const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
   if (!hasBeenInitialized && !isEmpty(data)) {
     setInitializedState(true);
     formik.setValues({
+      autoSync: get(data, "autoSync", formDefinition.defaultValues.autoSync) ?? true,
       type: get(data, "type", formDefinition.defaultValues.type),
       related: get(data, "related.value", formDefinition.defaultValues.related),
       relatedType: get(data, "relatedType.value", formDefinition.defaultValues.relatedType),
@@ -184,7 +183,7 @@ const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
       [name]: value,
     }));
 
-    if (name === "related" && relatedTypeSelectValue && autoSync) {
+    if (name === "related" && relatedTypeSelectValue && formik.values.autoSync) {
       const { contentTypesNameFields, pathDefaultFields } = config;
       const selectedRelated =  contentTypeEntities.find(({ id, __collectionUid }) =>
         `${id}` === `${value}` && __collectionUid === relatedTypeSelectValue
@@ -548,8 +547,8 @@ const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
                     intlLabel={getTrad('popup.item.form.autoSync.label', 'Read fields from related')}
                     name="autoSync"
                     type="bool"
-                    onChange={({ target: { value } }: GenericInputOnChangeInput) => setAutoSync(value)}
-                    value={autoSync}
+                    onChange={({ target: { name, value } }: GenericInputOnChangeInput) => onChange({ name, value })}
+                    value={formik.values.autoSync}
                   />
                 </GridItem>
                 <GridItem col={6} lg={12}>

--- a/admin/src/pages/View/components/NavigationItemForm/types.ts
+++ b/admin/src/pages/View/components/NavigationItemForm/types.ts
@@ -84,6 +84,7 @@ export type NavigationItemFormProps = {
 export type ContentTypeSearchQuery = ToBeFixed;
 export type RawFormPayload = {
   type: NavigationItemType;
+  autoSync?: boolean;
   related?: string;
   relatedType?: string;
   audience: Id[];

--- a/admin/src/pages/View/components/NavigationItemForm/utils/form.ts
+++ b/admin/src/pages/View/components/NavigationItemForm/utils/form.ts
@@ -15,6 +15,7 @@ const externalPathRegexps = [
 
 export const schemaFactory = (isSingleSelected: boolean, additionalFields: NavigationItemAdditionalField[]) => {
   return yup.object({
+    autoSync: yup.bool().optional(),
     title: yup.string()
       .when('type', {
         is: (val: NavigationItemType) => val !== navigationItemType.INTERNAL,
@@ -86,6 +87,7 @@ export const schemaFactory = (isSingleSelected: boolean, additionalFields: Navig
 };
 
 export const defaultValues: RawFormPayload = {
+  autoSync: true,
   type: "INTERNAL",
   related: "",
   relatedType: "",

--- a/admin/src/pages/View/utils/parsers.js
+++ b/admin/src/pages/View/utils/parsers.js
@@ -27,6 +27,7 @@ export const transformItemToRESTPayload = (
     collapsed,
     isSingle,
     additionalFields = {},
+    autoSync,
   } = item;
   const isExternal = type === navigationItemType.EXTERNAL;
   const isWrapper = type === navigationItemType.WRAPPER;
@@ -52,6 +53,7 @@ export const transformItemToRESTPayload = (
     uiRouterKey,
     collapsed,
     additionalFields,
+    autoSync,
     menuAttached: itemAttachedToMenu,
     audience: audience.map((audienceItem) =>
       isObject(audienceItem)

--- a/server/content-types/navigation-item/schema.ts
+++ b/server/content-types/navigation-item/schema.ts
@@ -71,6 +71,11 @@ export default {
       default: false,
       configurable: false
     },
+    autoSync: {
+      type: "boolean",
+      default: true,
+      configurable: false
+    },
     related: {
       type: "relation",
       relation: "oneToOne",

--- a/server/services/client.ts
+++ b/server/services/client.ts
@@ -424,7 +424,7 @@ const clientService: (context: StrapiContext) => IClientService = ({ strapi }) =
           }
 
           return result
-            .map(({ additionalFields, ...item }: NavigationItemEntity<ContentTypeEntity>) => {
+            .map(({ additionalFields, autoSync: _,  ...item }: NavigationItemEntity<ContentTypeEntity>) => {
               const customFields = enabledCustomFieldsNames.reduce((acc, field) => {
                 const mapper = customFieldsDefinitions.find(({ name }) => name === field)?.type === "media"
                   ? (_: string | boolean) => pickMediaFields(JSON.parse(_.toString()))

--- a/types/contentTypes.ts
+++ b/types/contentTypes.ts
@@ -38,6 +38,7 @@ export type NavigationItemEntity<RelatedType = NavigationItemRelated> = TypeResu
   externalPath: string | null;
   related: RelatedType | null;
   additionalFields: StringMap<string | boolean>;
+  autoSync?: boolean
 }>
 
 type NavigationItemPartial = {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/432
https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/427

## Summary

What does this PR do/solve? 

"Read fields from related" is persisted between navigation editions.

## Test Plan

- start the server
- open admin panel
- open navigation details
- add a new item
- set "Read fields from related" to false
- fill navigation item's details
- save
- refresh page
- open navigation item details form
- "Read fields from related" should be set to false