### PR TITLE
Feat/migration related id to document id

### DIFF
--- a/migrations/strapi-plugin-navigation-3.0.0-no-1-related-id-to-documentid.ts
+++ b/migrations/strapi-plugin-navigation-3.0.0-no-1-related-id-to-documentid.ts
@@ -10,9 +10,11 @@ export default {
 
     // Get all entries and rewrite directly to the navigation_items table
     const all = await knex.from(SOURCE_TABLE_NAME).columns('id', 'related_id', 'related_type').select();
+    
     await Promise.all(
       all.map(async (item) => {
         const { related_id, related_type, id: row_id} = item;
+        
         if (related_id && related_type && !isNaN(parseInt(related_id, 10))) {
           const newRelatedId = `${related_type}${RELATED_ITEM_SEPARATOR}${related_id}`;
           const link = await knex.from(SOURCE_LINK_TABLE_NAME).columns('navigation_item_id', 'navigations_items_related_id').select().where({ navigations_items_related_id: row_id });

--- a/migrations/strapi-plugin-navigation-3.0.0-no-1-related-id-to-documentid.ts
+++ b/migrations/strapi-plugin-navigation-3.0.0-no-1-related-id-to-documentid.ts
@@ -1,0 +1,37 @@
+const SOURCE_TABLE_NAME = 'navigations_items_related';
+const SOURCE_LINK_TABLE_NAME = 'navigations_items_related_links';
+const TARGET_TABLE_NAME = 'navigations_items';
+const RELATED_ITEM_SEPARATOR = '$';
+
+export default {
+  async up(knex) {
+
+    console.log("Navigation plugin :: Migrations :: Backup navigation item related table - START");
+
+    // Get all entries and rewrite directly to the navigation_items table
+    const all = await knex.from(SOURCE_TABLE_NAME).columns('id', 'related_id', 'related_type').select();
+    await Promise.all(
+      all.map(async (item) => {
+        const { related_id, related_type, id: row_id} = item;
+        if (related_id && related_type && !isNaN(parseInt(related_id, 10))) {
+          const newRelatedId = `${related_type}${RELATED_ITEM_SEPARATOR}${related_id}`;
+          const link = await knex.from(SOURCE_LINK_TABLE_NAME).columns('navigation_item_id', 'navigations_items_related_id').select().where({ navigations_items_related_id: row_id });
+          const nav_id = link[0].navigation_item_id;
+
+          await knex.from(TARGET_TABLE_NAME).update({ related: newRelatedId }).where({ id: nav_id });
+        }
+      })
+    );
+
+    // Drop the old tables
+    // await knex.schema.dropTable(SOURCE_TABLE_NAME);
+    // await knex.schema.dropTable(SOURCE_LINK_TABLE_NAME);
+
+    console.log("Navigation plugin :: Migrations :: Backup navigation item related table - DONE");
+
+    await strapi.db.transaction(async () => {
+      // Run related id to document id migration
+      await strapi.service('plugin::navigation.navigation').migrateRelatedIdToDocumentId();
+    });
+  },
+};

--- a/server/src/services/admin/utils.ts
+++ b/server/src/services/admin/utils.ts
@@ -55,10 +55,10 @@ export const processItems =
     let nextRelated = related;
 
     if (related && !context.entities.has(related)) {
-      const [uid, id] = related.split(RELATED_ITEM_SEPARATOR);
+      const [uid, documentId] = related.split(RELATED_ITEM_SEPARATOR);
 
-      const entity = await getGenericRepository(context, uid as UID.Schema).findById(
-        parseInt(id, 10),
+      const entity = await getGenericRepository(context, uid as UID.ContentType).findById(
+        documentId,
         true
       );
 

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,13 +1,16 @@
 import admin from './admin';
 import client from './client';
 import common from './common';
+import migrate from './migration';
 
 export type { AdminService } from './admin';
 export type { ClientService } from './client';
 export type { CommonService } from './common';
+export type { MigrationService } from './migration';
 
 export default {
   admin,
   common,
   client,
+  migrate,
 };

--- a/server/src/services/migration/index.ts
+++ b/server/src/services/migration/index.ts
@@ -1,0 +1,5 @@
+import migrationService from './migration';
+
+export type { MigrationService } from './migration';
+
+export default migrationService;

--- a/server/src/services/migration/migration.ts
+++ b/server/src/services/migration/migration.ts
@@ -1,0 +1,38 @@
+import { Core, UID } from '@strapi/strapi';
+import { isNaN } from 'lodash';
+import { getNavigationItemRepository } from '../../repositories';
+import { RELATED_ITEM_SEPARATOR } from '../../utils';
+
+export type MigrationService = ReturnType<typeof migrationService>;
+
+const migrationService = (context: { strapi: Core.Strapi }) => ({
+  async migrateRelatedIdToDocumentId(): Promise<void> {
+    console.log("Navigation plugin :: Migrations :: Relared id to document id - START");
+
+    const navigationItemRepository = getNavigationItemRepository(context);
+    const all = await navigationItemRepository.find({ where: {}, limit: Number.MAX_SAFE_INTEGER });
+
+    await Promise.all(
+      all.map(async (item) => {
+        if (item.related) {
+          const [uid, id] = item.related.split(RELATED_ITEM_SEPARATOR);
+
+          if (!isNaN(parseInt(id, 10))) {
+            const relatedItem = await context.strapi.query(uid as UID.Schema).findOne({ where: { id } })
+
+            if (relatedItem) {
+              await navigationItemRepository.save({
+                id: item.id,
+                related: `${uid}${RELATED_ITEM_SEPARATOR}${relatedItem.documentId}`,
+              });
+            }
+          }
+        }
+      })
+    );
+
+    console.log("Navigation plugin :: Migrations :: Relared id to document id - DONE");
+  },
+});
+
+export default migrationService;


### PR DESCRIPTION
## Ticket

#8695xu7t5

## Summary

What does this PR do/solve? 

Migrate from v4 structure to the v5 structure and then rebuild the relation string using `documentId` instead of `id`.

## Test Plan

1. Get your v4 database setup (backup first)
2. Upgrade to v5
3. Copy files from `./migrations` to your Strapi instance `./database/migrations`
4. Run and see the structure was migrated
