### PR TITLE
fix: form defaults

### DIFF
--- a/admin/src/pages/HomePage/components/NavigationItemForm/utils/form.ts
+++ b/admin/src/pages/HomePage/components/NavigationItemForm/utils/form.ts
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { NavigationItemAdditionalField } from '../../../../../schemas';
@@ -122,22 +123,30 @@ const navigationItemFormSchema = (input: FormSchemaBuilderInput) =>
 
 export const useNavigationItemForm = ({
   input,
-  current = defaultValues,
+  current = fallbackDefaultValues,
 }: {
   input: FormSchemaBuilderInput;
   current?: NavigationItemFormSchema;
 }) => {
-  return useForm({
+  const defaultValues = useMemo(
+    (): NavigationItemFormSchema =>
+      // TODO: Update after migration
+      // @ts-expect-error
+      ({
+        ...fallbackDefaultValues,
+        ...current,
+        updated: !!current.documentId,
+      }),
+    [current]
+  );
+
+  return useForm<NavigationItemFormSchema>({
     resolver: zodResolver(navigationItemFormSchema(input)),
-    values: {
-      ...defaultValues,
-      ...current,
-      updated: !!current.id,
-    },
+    defaultValues,
   });
 };
 
-export const defaultValues: NavigationItemFormSchema = {
+export const fallbackDefaultValues: NavigationItemFormSchema = {
   autoSync: true,
   type: 'INTERNAL',
   relatedType: '',

--- a/admin/src/pages/SettingsPage/components/CustomFieldForm/hooks/index.ts
+++ b/admin/src/pages/SettingsPage/components/CustomFieldForm/hooks/index.ts
@@ -5,7 +5,9 @@ import { NavigationItemCustomField, navigationItemCustomField } from '../../../.
 export const useCustomFieldForm = (customField: Partial<NavigationItemCustomField>) => {
   const form = useForm({
     resolver: zodResolver(navigationItemCustomField),
-    values: customField,
+    // TODO: Update on proper fix
+    // @ts-expect-error
+    defaultValues: customField,
   });
 
   return form;

--- a/admin/src/pages/SettingsPage/hooks/index.ts
+++ b/admin/src/pages/SettingsPage/hooks/index.ts
@@ -108,7 +108,7 @@ export const uiFormSchema = configSchema.omit({ contentTypesNameFields: true }).
 export const useSettingsForm = (config?: ConfigSchema) => {
   const form = useForm({
     resolver: zodResolver(uiFormSchema),
-    values: config
+    defaultValues: config
       ? {
           ...config,
           additionalFields: config.additionalFields.filter((field) => typeof field !== 'string'),


### PR DESCRIPTION
## Summary

What does this PR do/solve? 

Form text inputs where not responding correctly to changes in input forms. It was an issue with `values` and `defaultValues` mixed up

## Test Plan

- start an app
- edit (or created then edit) navigation item
- change it's title
- title should editable with no issues