### PR TITLE
feat: navigation unified slug

### DIFF
--- a/migrations/strapi-plugin-navigation-3.0.0-no-2-locale-slug-regular-slug.ts
+++ b/migrations/strapi-plugin-navigation-3.0.0-no-2-locale-slug-regular-slug.ts
@@ -1,0 +1,30 @@
+const SOURCE_TABLE_NAME = 'navigations';
+
+export default {
+  async up(knex) {
+    // Get all entries and rewrite directly to the navigation_items table
+    const all = await knex.from(SOURCE_TABLE_NAME).columns('id', 'slug', 'locale').select();
+
+    const run = async () => {
+      await Promise.all(
+        all.map(async (item: { id: number; slug: string; locale: string }) => {
+          const { id, slug, locale } = item;
+
+          if (slug && locale && id) {
+            const regex = new RegExp(`-${locale}$`);
+
+            await knex
+              .from(SOURCE_TABLE_NAME)
+              .update({ slug: slug.replace(regex, '') })
+              .where({ id });
+          }
+        })
+      );
+    };
+
+    await strapi.db.transaction(async () => {
+      // Run related id to document id migration
+      await run();
+    });
+  },
+};

--- a/server/src/i18n/index.ts
+++ b/server/src/i18n/index.ts
@@ -24,14 +24,12 @@ export const navigationSetup = async (context: { strapi: Core.Strapi }) => {
         name: DEFAULT_NAVIGATION_NAME,
         visible: true,
         locale: defaultLocale,
-        slug: `${DEFAULT_NAVIGATION_SLUG}-${defaultLocale}`,
+        slug: DEFAULT_NAVIGATION_SLUG,
       })
     );
   }
 
-  const defaultLocaleNavigations = navigations.filter(
-    ({ locale }) => locale === defaultLocale
-  );
+  const defaultLocaleNavigations = navigations.filter(({ locale }) => locale === defaultLocale);
 
   for (const defaultLocaleNavigation of defaultLocaleNavigations) {
     for (const otherLocale of restLocale) {
@@ -46,7 +44,7 @@ export const navigationSetup = async (context: { strapi: Core.Strapi }) => {
           name: defaultLocaleNavigation.name,
           locale: otherLocale,
           visible: defaultLocaleNavigation.visible,
-          slug: `${defaultLocaleNavigation.slug.replace(`-${defaultLocale}`, '')}-${otherLocale}`,
+          slug: defaultLocaleNavigation.slug,
         });
       }
     }


### PR DESCRIPTION
## Ticket

N/A

## Summary

What does this PR do/solve? 

Navigation slug unified. Locale present in query.

## Test Plan

- use migration specified
- start the app
- all navigation slugs should have locale suffix dropped
- on navigation name edit all locale versions have the same, newly generated slugs