### PR TITLE
fix: boolean additional fields

### DIFF
--- a/admin/src/pages/HomePage/components/AdditionalFieldInput/index.tsx
+++ b/admin/src/pages/HomePage/components/AdditionalFieldInput/index.tsx
@@ -75,7 +75,7 @@ export const AdditionalFieldInput: React.FC<AdditionalFieldInputProps> = ({
         <Toggle
           {...defaultInputProps}
           checked={!!value}
-          onChange={(eventOrPath: React.ChangeEvent<any> | string, value?: any) => onChangeEnhancer(eventOrPath, !value, onChange)}
+          onChange={(eventOrPath: React.ChangeEvent<any> | string) => onChangeEnhancer(eventOrPath, !value, onChange)}
           onLabel="true"
           offLabel="false"
           type="checkbox"


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/468

## Summary

Boolean additional fields were not editable. Change listener set `value` to `!value` what resulted in `!undefined`

## Test Plan

- start the app
- set boolean additional field
- edit navigation item
- set additional field on navigation item to `false`
- save
- refresh
- field should preserved as `false`