### PR TITLE
fix: server restart on server page

### DIFF
--- a/server/src/services/admin/admin.ts
+++ b/server/src/services/admin/admin.ts
@@ -526,6 +526,8 @@ const adminService = (context: { strapi: Core.Strapi }) => ({
   },
 
   async restart(): Promise<void> {
+    context.strapi.reload.isWatching = false;
+
     setImmediate(() => context.strapi.reload());
   },
 


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/462

## Summary

Restart handling on settings page

## Test Plan

- start the server
- go to plugin's settings page
- save settings
- click restart
- loader should be visible for all of the restart time