### PR TITLE
fix: missing media type additional file

### DIFF
--- a/admin/src/components/AdditionalFieldInput/index.tsx
+++ b/admin/src/components/AdditionalFieldInput/index.tsx
@@ -128,7 +128,7 @@ const AdditionalFieldInput: React.FC<AdditionalFieldInputProps> = ({
           id="navigation-item-media"
           onChange={handleMedia}
           value={value || []}
-          intlLabel={defaultInputProps.label}
+          intlLabel={{ id: defaultInputProps.label, defaultMessage: defaultInputProps.label }}
           attribute={mediaAttribute}
         />
       );


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/467

## Summary

What does this PR do/solve? 

Missing label for media type additional field

## Test Plan

- start the server
- add media additional field to navigation item
- go to navigation form
- add navigation item
- label should be present for media field