### PR TITLE
Fix/pr 486 gql remove attributes prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,16 +571,14 @@ query {
     path
     related {
       id
-      attributes {
-        __typename
+      __typename
 
-        ... on Page {
-          Title
-        }
+      ... on Page {
+        Title
+      }
 
-        ... on WithFlowType {
-          Name
-        }
+      ... on WithFlowType {
+        Name
       }
     }
     items {
@@ -589,16 +587,14 @@ query {
       path
       related {
         id
-        attributes {
-          __typename
+        __typename
 
-          ... on Page {
-            Title
-          }
+        ... on Page {
+          Title
+        }
 
-          ... on WithFlowType {
-            Name
-          }
+        ... on WithFlowType {
+          Name
         }
       }
     }
@@ -618,10 +614,8 @@ query {
         "path": "/test-path",
         "related": {
           "id": 3,
-          "attributes": {
-            "__typename": "WithFlowType",
-            "Name": "Test"
-          }
+          "__typename": "WithFlowType",
+          "Name": "Test"
         },
         "items": [
           {
@@ -630,10 +624,8 @@ query {
             "path": "/test-path/nested-one",
             "related": {
               "id": 1,
-              "attributes": {
-                  "__typename": "Page",
-                "Title": "Eg. Page title"
-              }
+              "__typename": "Page",
+              "Title": "Eg. Page title"
             }
           }
         ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-navigation",
-  "version": "3.0.3-beta.1",
+  "version": "3.0.3",
   "description": "Strapi - Navigation plugin",
   "strapi": {
     "name": "navigation",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-navigation",
-  "version": "3.0.2",
+  "version": "3.0.3-beta.1",
   "description": "Strapi - Navigation plugin",
   "strapi": {
     "name": "navigation",

--- a/server/src/dtos/navigation-item.ts
+++ b/server/src/dtos/navigation-item.ts
@@ -5,12 +5,17 @@ export type NavigationItemDTO = Omit<
   NavigationItemDBSchema,
   'related' | 'items' | 'master' | 'parent'
 > & {
-  related?: { __type: string; documentId: string } | null;
+  related?: NavigationItemRelatedDTO | null;
   items?: NavigationItemDTO[];
   master?: NavigationDTO;
   parent?: NavigationItemDTO | null;
   order?: number;
 };
+
+export type NavigationItemRelatedDTO = {
+  __type: string;
+  documentId: string;
+}
 
 export type CreateBranchNavigationItemDTO = Omit<NavigationItemDBSchema, 'id' | 'documentId' | 'items'> & {
   id?: number;

--- a/server/src/graphql/types/index.ts
+++ b/server/src/graphql/types/index.ts
@@ -10,14 +10,12 @@ import navigationItem from './navigation-item';
 import navigationItemAdditionalFields from './navigation-item-additional-fields';
 import navigationItemAdditionalFieldMedia from './navigation-item-additional-field-media';
 import navigationItemRelated from './navigation-item-related';
-import navigationItemRelatedData from './navigation-item-related-data';
 import renderType from './navigation-render-type';
 
 const typesFactories = [
   navigationItemAdditionalFieldMedia,
   navigationItemAdditionalFields,
   navigationItemRelated,
-  navigationItemRelatedData,
   navigationItem,
   renderType,
   navigation,

--- a/server/src/graphql/types/navigation-item-related-data.ts
+++ b/server/src/graphql/types/navigation-item-related-data.ts
@@ -1,9 +1,0 @@
-export default ({ nexus }: any) =>
-  nexus.objectType({
-    name: 'NavigationItemRelatedData',
-    definition(t: any) {
-      t.int('id');
-      t.nonNull.string('documentId');
-      t.field('attributes', { type: 'NavigationItemRelated' });
-    },
-  });

--- a/server/src/graphql/types/navigation-item-related.ts
+++ b/server/src/graphql/types/navigation-item-related.ts
@@ -1,3 +1,5 @@
+import { NavigationItemRelatedDTO } from '../../dtos';
+
 export default ({ strapi, nexus, config }: any) => {
 	const related = config.gql?.navigationItemRelated;
 	const name = "NavigationItemRelated";
@@ -8,12 +10,12 @@ export default ({ strapi, nexus, config }: any) => {
 			definition(t: any) {
 				t.members(...related)
 			},
-			resolveType: (item: { uid: string }) => {
-				return strapi.contentTypes[item.uid]?.globalId
+			resolveType: (item: NavigationItemRelatedDTO) => {
+				return strapi.contentTypes[item.__type]?.globalId
 			}
 		});
 	}
-	
+
 	return nexus.objectType({
 		name,
 		definition(t: any) {

--- a/server/src/graphql/types/navigation-item.ts
+++ b/server/src/graphql/types/navigation-item.ts
@@ -16,7 +16,7 @@ export default ({ nexus, config }: any) =>
       t.field('parent', { type: 'NavigationItem' });
       t.string('master');
       t.list.field('items', { type: 'NavigationItem' });
-      t.field('related', { type: 'NavigationItemRelatedData' });
+      t.field('related', { type: 'NavigationItemRelated' });
 
       if (config.additionalFields.find((field: NavigationItemAdditionalField) => field === 'audience')) {
         t.list.string('audience');


### PR DESCRIPTION
## Ticket

Original PR: https://github.com/VirtusLab/strapi-plugin-navigation/issues/486 by @jorrit
Issue: https://github.com/VirtusLab/strapi-plugin-navigation/issues/485 by @jorrit

## Summary

What does this PR do/solve? 

Removes `attributes` from the GQL calls.
