### PR TITLE
fix: additional fields

### DIFF
--- a/server/src/services/client/types.ts
+++ b/server/src/services/client/types.ts
@@ -30,7 +30,10 @@ export interface RenderRFRInput {
 }
 
 export interface RenderRFRNavInput {
-  item: Pick<NavigationItemDTO, 'uiRouterKey' | 'title' | 'path' | 'type' | 'audience'>;
+  item: Pick<
+    NavigationItemDTO,
+    'uiRouterKey' | 'title' | 'path' | 'type' | 'audience' | 'additionalFields'
+  >;
 }
 
 export interface RenderRFRPageInput {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/492

## Summary

- additional fields not rendered in the navigation item. 
- unified way of rendering additional fields for all render types

## Test Plan

- start the app
- set additional fields on navigation item, if not present
- render navigation as `RFR`, `FLAT`, `TREE` and default
- additional fields should be present
- render navigation via GraphQL query
- additional fields should be present

