### PR TITLE
fix: navigation item form error message

### DIFF
--- a/admin/src/pages/HomePage/components/NavigationItemForm/index.tsx
+++ b/admin/src/pages/HomePage/components/NavigationItemForm/index.tsx
@@ -270,12 +270,8 @@ export const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
     }
   };
 
-  const renderError = (error: string): string | undefined => {
-    const errorOccurence = get(formError, error);
-    if (errorOccurence) {
-      return formatMessage(getTrad(error));
-    }
-    return undefined;
+  const renderError = (field: string, messageKey?: string): string | undefined => {
+    return get(formError, field) ? formatMessage(getTrad(messageKey ?? field)) : undefined;
   };
 
   const initialRelatedTypeSelected = current.type === 'INTERNAL' ? current.relatedType : undefined;
@@ -695,7 +691,7 @@ export const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
                       label={formatMessage(
                         getTrad(`popup.item.form.${pathSourceName}.label`, 'Path')
                       )}
-                      error={renderError(pathSourceName)}
+                      error={renderError(pathSourceName, `popup.item.form.${pathSourceName}.validation.type`)}
                       hint={[
                         formatMessage(
                           getTrad(`popup.item.form.${pathSourceName}.placeholder`, 'e.g. Blog')


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/495

## Summary

Fix for item form error message rendering

## Test Plan

- start the app
- add new navigation item
- select `EXTERNAL` type
- try to save
- external path message should render