### PR TITLE
fix: select additional field type

### DIFF
--- a/admin/src/components/TextArrayInput/index.tsx
+++ b/admin/src/components/TextArrayInput/index.tsx
@@ -17,15 +17,17 @@ const TextArrayInput: React.FC<IProps> = ({ onChange, initialValue, ...props }) 
   const [value, setValue] = useState(
     isArray(initialValue) ? initialValue.reduce((acc, cur) => `${acc}${cur}; `, '') : ''
   );
-  const handleOnChange = (value: string) => {
-    const newValue: string = value;
+  const handleOnChange = (event: { target: { value?: string } }) => {
+    const newValue: string = event?.target.value ?? '';
     const valuesArray = newValue
       .split(';')
-      .map((v) => v.trim())
-      .filter((v) => !!v.length);
-    setValue(value);
+      .map((value) => value.trim())
+      .filter((value) => !!value.length);
+
+    setValue(newValue ?? '');
     onChange(valuesArray);
   };
+
   return <TextInput {...props} onChange={handleOnChange} value={value} />;
 };
 


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/494

## Summary

Setting `select` additional field available options

## Test Plan

- start the server
- go to navigation plugin settings
- add additional field of select type
- set available options
- save settings and restart
- add new navigation item
- set field's value
- save
- render edited navigation
- additional field should be present in the result