### PR TITLE
fix: unify menu icon size with those of Strapi

### DIFF
--- a/admin/src/components/icons/navigation.tsx
+++ b/admin/src/components/icons/navigation.tsx
@@ -8,9 +8,9 @@ const NavigationIconSvg = styled.svg`
   }
 `;
 
-export const NavigationIcon = ({ width = 24, height = 24 }) => (
+export const NavigationIcon = ({ width = 20, height = 20 }) => (
   <NavigationIconSvg
-    viewBox={`0px 0px ${width}px ${height}px`}
+    viewBox={`0 0 ${width} ${height}`}
     xmlns="http://www.w3.org/2000/svg"
     height={height}
     width={width}


### PR DESCRIPTION
## Summary

Change the size of Navigation plugin's menu icon to align with those of Strapi itself, which is 20px.
![image](https://github.com/user-attachments/assets/b183fd42-766e-4349-ae96-09ea20a19527)


## Test Plan
As it is only a style change, I tested it in the inspector.
