### PR TITLE
Fix console warning about unknown HTML properties

### DIFF
--- a/admin/src/pages/SettingsPage/index.tsx
+++ b/admin/src/pages/SettingsPage/index.tsx
@@ -740,7 +740,7 @@ const Inner = () => {
                   </Flex>
                 </Box>
 
-                <Box {...BOX_DEFAULT_PROPS} width="100%" gap={2} direction="column" alignItems="flex-start">
+                <Box {...BOX_DEFAULT_PROPS} width="100%">
                   <Typography variant="delta" as="h2">
                     {formatMessage(getTrad('pages.settings.customFields.title'))}
                   </Typography>


### PR DESCRIPTION
## Summary

This console warning is displayed when accessing the Settings page at http://localhost:1337/admin/settings/navigation :

> React does not recognize the `alignItems` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `alignitems` instead. If you accidentally passed it from a parent component, remove it from the DOM element. Error Component Stack
 
The cause is the presence of invalid attributes on the Box component. These attributes belong to the Flex component, I guess this was a copy-paste mistake.

## Test Plan

Open the Settings page, check the developer console of your browser for React errors.