### PR TITLE
fix: fill from other locale

### DIFF
--- a/admin/src/pages/HomePage/hooks/index.tsx
+++ b/admin/src/pages/HomePage/hooks/index.tsx
@@ -47,6 +47,32 @@ export const useContentTypes = () => {
   });
 };
 
+export const useResetNavigations = () => {
+  const fetch = getFetchClient();
+  const apiClient = getApiClient(fetch);
+
+  const queryClient = useQueryClient();
+
+  return () => {
+    queryClient.resetQueries({
+      queryKey: apiClient.readAllIndex(),
+    });
+  };
+};
+
+export const useResetContentTypes = () => {
+  const fetch = getFetchClient();
+  const apiClient = getApiClient(fetch);
+
+  const queryClient = useQueryClient();
+
+  return () => {
+    queryClient.resetQueries({
+      queryKey: apiClient.readContentTypeIndex(),
+    });
+  };
+};
+
 export const useNavigations = () => {
   const fetch = getFetchClient();
   const apiClient = getApiClient(fetch);
@@ -158,7 +184,9 @@ export const usePurgeNavigation = () => {
         return apiClient.purge({});
       }
 
-      return Promise.all(documentIds.map((documentId) => apiClient.purge({ documentId, withLangVersions: true })));
+      return Promise.all(
+        documentIds.map((documentId) => apiClient.purge({ documentId, withLangVersions: true }))
+      );
     },
   });
 };
@@ -207,7 +235,7 @@ export const useI18nCopyNavigationItemsModal = (onConfirm: ConfirmEffect) => {
   );
 };
 
-const appendViewId = (item: NavigationItemSchema): NavigationItemSchema => {
+export const appendViewId = (item: NavigationItemSchema): NavigationItemSchema => {
   return {
     ...item,
     viewId: Math.floor(Math.random() * 1520000),

--- a/server/src/services/admin/types.ts
+++ b/server/src/services/admin/types.ts
@@ -18,6 +18,7 @@ export interface GetInput {
 export interface GetByIdInput {
   documentId: string;
   locale?: string;
+  populate?: Array<string>
 }
 
 export interface PostInput {

--- a/server/src/services/admin/utils.ts
+++ b/server/src/services/admin/utils.ts
@@ -67,6 +67,7 @@ export const processItems =
       master: context.master,
       parent: undefined,
       related: item.related,
+      additionalFields: item.additionalFields,
     };
   };
 


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/496

## Summary

- related field not being copied on fill
- custom fields not being copied on fill
- missing viewId on navigation copied from other locale

## Test Plan

- start the server
- go to `Navigation` view
- have a filled navigation from one locale, and empty for other locale
- have internal items and additional fields on first locale
- fill from other locale
- all required info is copied from the source
- remove a navigation item on newly created navigation
- restore a navigation item on newly created navigation
- save
- refresh view
