### PR TITLE
feat: populating navigation item related

### DIFF
--- a/server/src/services/client/client.ts
+++ b/server/src/services/client/client.ts
@@ -1,6 +1,6 @@
 import { Core } from '@strapi/strapi';
 import { errors } from '@strapi/utils';
-import { cloneDeep, first, get, isArray, isEmpty, isNil, last, pick } from 'lodash';
+import { cloneDeep, first, isArray, isEmpty, isNil, last, pick } from 'lodash';
 import { NavigationError } from '../../app-errors';
 import { NavigationItemDTO, RFRNavigationItemDTO, RFRPageDTO } from '../../dtos';
 import { getNavigationItemRepository, getNavigationRepository } from '../../repositories';
@@ -75,11 +75,21 @@ const clientService = (context: { strapi: Core.Strapi }) => ({
   },
 
   renderRFRPage({ item, parent, enabledCustomFieldsNames }: RenderRFRPageInput): RFRPageDTO {
-    const { documentId, uiRouterKey, title, path, related, type, audience, menuAttached, additionalFields } = item;
+    const {
+      documentId,
+      uiRouterKey,
+      title,
+      path,
+      related,
+      type,
+      audience,
+      menuAttached,
+      additionalFields,
+    } = item;
     const additionalFieldsRendered = enabledCustomFieldsNames.reduce(
-        (acc, field) => ({ ...acc, [field]: additionalFields?.[field] }),
-        {}
-      )
+      (acc, field) => ({ ...acc, [field]: additionalFields?.[field] }),
+      {}
+    );
 
     return {
       id: uiRouterKey,
@@ -273,9 +283,10 @@ const clientService = (context: { strapi: Core.Strapi }) => ({
       });
 
       const mappedItems = await commonService.mapToNavigationItemDTO({
+        locale,
+        master: navigation,
         navigationItems,
         populate,
-        master: navigation,
       });
 
       const { contentTypes, contentTypesNameFields, additionalFields } = await adminService.config({

--- a/server/src/services/common/types.ts
+++ b/server/src/services/common/types.ts
@@ -28,6 +28,7 @@ export interface MapToNavigationItemDTOInput {
   populate: unknown;
   master?: Omit<NavigationDTO, 'items'>;
   parent?: NavigationItemDTO;
+  locale?: string;
 }
 
 export interface CreateBranchInput {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/501

## Summary

Taking into account `contentTypesPopulate` when rendering navigation

## Test Plan

- start the server
- set `contentTypesPopulate` field in navigation
- prepare internal content to have relational fields filled
- render a navigation
- navigation item's related field should be populated as expected