### PR TITLE
Create GraphQL enum for navigation item type

### DIFF
--- a/server/src/graphql/types/create-navigation-item.ts
+++ b/server/src/graphql/types/create-navigation-item.ts
@@ -3,7 +3,7 @@ export default ({ nexus }: any) =>
     name: 'CreateNavigationItem',
     definition(t: any) {
       t.nonNull.string('title');
-      t.nonNull.string('type');
+      t.nonNull.field('type', { type: 'NavigationItemType' });
       t.string('path');
       t.string('externalPath');
       t.nonNull.string('uiRouterKey');

--- a/server/src/graphql/types/index.ts
+++ b/server/src/graphql/types/index.ts
@@ -10,6 +10,7 @@ import navigationItem from './navigation-item';
 import navigationItemAdditionalFields from './navigation-item-additional-fields';
 import navigationItemAdditionalFieldMedia from './navigation-item-additional-field-media';
 import navigationItemRelated from './navigation-item-related';
+import navigationItemType from './navigation-item-type';
 import renderType from './navigation-render-type';
 
 const typesFactories = [
@@ -26,6 +27,7 @@ const typesFactories = [
   createNavigationRelated,
   createNavigationItem,
   createNavigations,
+  navigationItemType,
 ];
 
 export const getTypes = (context: any) => {

--- a/server/src/graphql/types/navigation-item-type.ts
+++ b/server/src/graphql/types/navigation-item-type.ts
@@ -1,0 +1,5 @@
+export default ({ nexus }: any) =>
+  nexus.enumType({
+    name: 'NavigationItemType',
+    members: ['INTERNAL', 'EXTERNAL', 'WRAPPER'],
+  });

--- a/server/src/graphql/types/navigation-item.ts
+++ b/server/src/graphql/types/navigation-item.ts
@@ -7,7 +7,7 @@ export default ({ nexus, config }: any) =>
       t.nonNull.int('id');
       t.nonNull.string('documentId');
       t.nonNull.string('title');
-      t.nonNull.string('type');
+      t.nonNull.field('type', { type: 'NavigationItemType' });
       t.string('path');
       t.string('externalPath');
       t.nonNull.string('uiRouterKey');


### PR DESCRIPTION
## Summary

The navigation item type can be one of `INTERNAL`, `EXTERNAL` or `WRAPPER`. Currently, this is exposed as a string field. It is trivial to turn this into a proper GraphQL enum (like `NavigationRenderType` already is).

## Test Plan

Query the plugin using GraphQL, notice the new enum.
On the wire, nothing changes as the field is still returned as a JSON string. However, GraphQL tooling will now know what values to expect.