### PR TITLE
Sort related content types and entities by name

### DIFF
--- a/admin/src/pages/HomePage/components/NavigationItemForm/index.tsx
+++ b/admin/src/pages/HomePage/components/NavigationItemForm/index.tsx
@@ -381,7 +381,7 @@ export const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
         label: label,
       };
     }) ?? [],
-    (item) => item.key
+    (item) => item.label
   );
 
   const relatedTypeSelectOptions = useMemo(
@@ -405,7 +405,7 @@ export const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
               label: item.contentTypeName,
             };
           }),
-        (item) => item.key
+        (item) => item.label
       ),
     [configQuery.data, currentRelatedType]
   );


### PR DESCRIPTION
Fixes #507

## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/507

## Summary

The contents of the related content type and related content entity are now sorted by label.

## Test Plan

Open the add menu item dialog, observe the sorting in the related content type and entity are now sorted by label.