### PR TITLE
feat: external items with children

### DIFF
--- a/admin/src/pages/HomePage/components/NavigationItemListItem/index.tsx
+++ b/admin/src/pages/HomePage/components/NavigationItemListItem/index.tsx
@@ -105,7 +105,7 @@ export const Item: React.FC<Props> = ({
     ? level < configQuery.data.allowedLevels
     : true;
 
-  const hasChildren = !isEmpty(item.items) && !isExternal && !displayChildren;
+  const hasChildren = !isEmpty(item.items) && !displayChildren;
   const absolutePath = isExternal
     ? undefined
     : `${levelPath === '/' ? '' : levelPath}/${mappedItem.path === '/' ? '' : mappedItem.path}`.replace(
@@ -348,83 +348,83 @@ export const Item: React.FC<Props> = ({
               isSearchActive={mappedItem.isSearchActive}
             />
           </CardBody>
+
           <Divider />
-          {!isExternal && (
-            <CardBody style={{ padding: '8px' }}>
-              <Flex
-                style={{ width: '100%' }}
-                direction="row"
-                alignItems="center"
-                justifyContent="space-between"
-              >
-                <Flex>
-                  {!isEmpty(item.items) && (
-                    <CollapseButton
-                      toggle={() => onItemToggleCollapse({ ...item, viewParentId })}
-                      collapsed={mappedItem.collapsed}
-                      itemsCount={item.items?.length ?? 0}
-                    />
-                  )}
-                  {canUpdate && isNextMenuAllowedLevel && (
-                    <TextButton
-                      disabled={mappedItem.removed}
-                      startIcon={<Plus />}
-                      onClick={onNewItemClick}
+
+          <CardBody style={{ padding: '8px' }}>
+            <Flex
+              style={{ width: '100%' }}
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Flex>
+                {!isEmpty(item.items) && (
+                  <CollapseButton
+                    toggle={() => onItemToggleCollapse({ ...item, viewParentId })}
+                    collapsed={mappedItem.collapsed}
+                    itemsCount={item.items?.length ?? 0}
+                  />
+                )}
+                {canUpdate && isNextMenuAllowedLevel && (
+                  <TextButton
+                    disabled={mappedItem.removed}
+                    startIcon={<Plus />}
+                    onClick={onNewItemClick}
+                  >
+                    <Typography
+                      variant="pi"
+                      fontWeight="bold"
+                      textColor={mappedItem.removed ? 'neutral600' : 'primary600'}
                     >
-                      <Typography
-                        variant="pi"
-                        fontWeight="bold"
-                        textColor={mappedItem.removed ? 'neutral600' : 'primary600'}
-                      >
-                        {formatMessage(getTrad('components.navigationItem.action.newItem'))}
-                      </Typography>
-                    </TextButton>
-                  )}
-                </Flex>
-                {mappedItem.type === 'INTERNAL' && mappedItem.related && !relatedItem.id ? (
-                  <Flex justifyContent="center" alignItems="center">
-                    <Typography variant="omega" textColor="neutral600">
-                      {relatedTypeLabel}&nbsp;/&nbsp;
+                      {formatMessage(getTrad('components.navigationItem.action.newItem'))}
                     </Typography>
-                    <Typography variant="omega" textColor="neutral800">
-                      {formatMessage(getTrad('components.navigationItem.related.localeMissing'))}
-                    </Typography>
-                  </Flex>
-                ) : null}
-                {relatedItemLabel && (
-                  <Flex justifyContent="center" alignItems="center">
-                    {isHandledByPublishFlow && (
-                      <ItemCardBadge
-                        borderColor={`${relatedBadgeColor}200`}
-                        backgroundColor={`${relatedBadgeColor}100`}
-                        textColor={`${relatedBadgeColor}600`}
-                        className="action"
-                        small
-                      >
-                        {formatMessage(
-                          getTrad(
-                            `components.navigationItem.badge.${isPublished ? 'published' : 'draft'}`
-                          )
-                        )}
-                      </ItemCardBadge>
-                    )}
-                    <Typography variant="omega" textColor="neutral600">
-                      {relatedTypeLabel}&nbsp;/&nbsp;
-                    </Typography>
-                    <Typography variant="omega" textColor="neutral800">
-                      {relatedItemLabel}
-                    </Typography>
-                    <Link
-                      href={generatePreviewUrl(relatedItem ?? undefined)}
-                      endIcon={<ArrowRight />}
-                    >
-                      &nbsp;
-                    </Link>
-                  </Flex>
+                  </TextButton>
                 )}
               </Flex>
-            </CardBody>
-          )}
+              {mappedItem.type === 'INTERNAL' && mappedItem.related && !relatedItem.id ? (
+                <Flex justifyContent="center" alignItems="center">
+                  <Typography variant="omega" textColor="neutral600">
+                    {relatedTypeLabel}&nbsp;/&nbsp;
+                  </Typography>
+                  <Typography variant="omega" textColor="neutral800">
+                    {formatMessage(getTrad('components.navigationItem.related.localeMissing'))}
+                  </Typography>
+                </Flex>
+              ) : null}
+              {relatedItemLabel && (
+                <Flex justifyContent="center" alignItems="center">
+                  {isHandledByPublishFlow && (
+                    <ItemCardBadge
+                      borderColor={`${relatedBadgeColor}200`}
+                      backgroundColor={`${relatedBadgeColor}100`}
+                      textColor={`${relatedBadgeColor}600`}
+                      className="action"
+                      small
+                    >
+                      {formatMessage(
+                        getTrad(
+                          `components.navigationItem.badge.${isPublished ? 'published' : 'draft'}`
+                        )
+                      )}
+                    </ItemCardBadge>
+                  )}
+                  <Typography variant="omega" textColor="neutral600">
+                    {relatedTypeLabel}&nbsp;/&nbsp;
+                  </Typography>
+                  <Typography variant="omega" textColor="neutral800">
+                    {relatedItemLabel}
+                  </Typography>
+                  <Link
+                    href={generatePreviewUrl(relatedItem ?? undefined)}
+                    endIcon={<ArrowRight />}
+                  >
+                    &nbsp;
+                  </Link>
+                </Flex>
+              )}
+            </Flex>
+          </CardBody>
         </div>
       </Card>
       {hasChildren && !mappedItem.removed && !mappedItem.collapsed && (

--- a/server/src/services/client/client.ts
+++ b/server/src/services/client/client.ts
@@ -153,7 +153,7 @@ const clientService = (context: { strapi: Core.Strapi }) => ({
           root: navItems,
         };
       } else {
-        const navigationLevel = navItems.filter((navItem) => navItem.type !== 'EXTERNAL');
+        const navigationLevel = navItems.filter((navItem) => navItem.type);
 
         if (!isEmpty(navigationLevel))
           nav = {
@@ -170,8 +170,9 @@ const clientService = (context: { strapi: Core.Strapi }) => ({
           contentTypes,
           enabledCustomFieldsNames,
         });
+
         const { pages: nestedPages } = this.renderRFR({
-          items: itemChildren?.filter((child) => child.type !== 'EXTERNAL') || [],
+          items: itemChildren || [],
           parent: itemPage.documentId,
           parentNavItem: itemNav,
           contentTypes,
@@ -378,14 +379,12 @@ const clientService = (context: { strapi: Core.Strapi }) => ({
                       ...relatedContentType,
                     },
               audience: !isEmpty(item.audience) ? item.audience : undefined,
-              items: isExternal
-                ? []
-                : await this.renderTree({
-                    itemParser,
-                    path: parentPath,
-                    documentId: item.documentId,
-                    items: mappedItems,
-                  }),
+              items: await this.renderTree({
+                itemParser,
+                path: parentPath,
+                documentId: item.documentId,
+                items: mappedItems,
+              }),
               collapsed: item.collapsed,
               additionalFields: customFields || {},
             };


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/516

## Summary

- external items with children adding enabled

## Test Plan

- start the server
- go to admin panel
- go to navigation screen
- add an external item
- add a child to an external item
- save
- items should be saved
- render changed navigation
- external items should be rendered with their children items