### PR TITLE
fix: combo box not filled when editing a menu item

### DIFF
--- a/admin/src/pages/HomePage/components/ControllableCombobox/index.tsx
+++ b/admin/src/pages/HomePage/components/ControllableCombobox/index.tsx
@@ -16,6 +16,14 @@ type ControllableComboboxProps = {
   disabled: boolean;
 };
 
+const findTextValue = (options: ControllableComboboxProps['options'], value: ControllableComboboxProps['value']): string => {
+  if (!value) {
+    return '';
+  }
+
+  return options.find(o => o.value === value)?.label ?? '';
+};
+
 export const ControllableCombobox: React.FC<ControllableComboboxProps> = ({
   name,
   onClear,
@@ -24,17 +32,11 @@ export const ControllableCombobox: React.FC<ControllableComboboxProps> = ({
   value,
   disabled,
 }) => {
-  const [textValue, setTextValue] = useState('');
-
-  const handleTextValueChange = (textValue: string) => {
-    setTextValue(textValue);
-  };
+  const [textValue, setTextValue] = useState(findTextValue(options, value));
 
   useEffect(() => {
-    if (!value) {
-      handleTextValueChange('');
-    }
-  }, [value]);
+    setTextValue(findTextValue(options, value))
+  }, [value, options]);
 
   return (
     <Combobox
@@ -42,7 +44,7 @@ export const ControllableCombobox: React.FC<ControllableComboboxProps> = ({
       autocomplete="list"
       onClear={onClear}
       onChange={onChange}
-      onTextValueChange={handleTextValueChange}
+      onTextValueChange={setTextValue}
       value={value}
       textValue={textValue}
       options={options}


### PR DESCRIPTION
## Summary

After 217e6f926568c4ef141900a6d94392ffd0800d85 was released, the combo boxes for the current content type / content item are empty when editing an existing menu item.

![image](https://github.com/user-attachments/assets/44656b63-eedb-4421-a5be-747eb8e0c6c1)

## Test Plan

Open an existing menu item that was associated with a content item. In 3.0.9 the combo boxes are empty, with this patch they're filled.

