### PR TITLE
fix: additional boolean fields db migration

### DIFF
--- a/migrations/strapi-plugin-navigation-3.0.0-no-4-additional-fields.js
+++ b/migrations/strapi-plugin-navigation-3.0.0-no-4-additional-fields.js
@@ -1,0 +1,39 @@
+const SOURCE_TABLE_NAME_NAVIGATION_ITEMS = "navigations_items";
+
+module.exports = {
+  async up(knex) {
+    const run = async () => {
+      const navigationItems = await knex
+        .from(SOURCE_TABLE_NAME_NAVIGATION_ITEMS)
+        .columns("id", "additional_fields")
+        .select();
+
+      for (const item of navigationItems) {
+        const { id, additional_fields, ...rest } = item;
+        const parsedFields = additional_fields
+          ? JSON.parse(additional_fields)
+          : undefined;
+
+        if (parsedFields) {
+          await knex(SOURCE_TABLE_NAME_NAVIGATION_ITEMS)
+            .where({ id })
+            .update(
+              {
+                additional_fields: JSON.stringify(
+                  Object.fromEntries(
+                    Object.entries(parsedFields).map(([key, value]) => [
+                      key,
+                      typeof value === "boolean" ? value.toString() : value,
+                    ])
+                  )
+                ),
+              },
+              ["id", "additional_fields"]
+            );
+        }
+      }
+    };
+
+    await strapi.db.transaction(run);
+  },
+};


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/553

## Summary

What does this PR do/solve? 

As described in the issue way of saving additional fields changed from version to version. A DB migration covers that migration.

## Test Plan

- copy migration file to your server 
- start the server
- check the admin panel