### PR TITLE
fix: admin ui after navigation save

### DIFF
--- a/admin/src/api/client.ts
+++ b/admin/src/api/client.ts
@@ -37,7 +37,10 @@ export const getApiClient = once((fetch: ReturnType<typeof getFetchClient>) => (
   },
 
   update(body: NavigationSchema) {
-    return fetch.put(`/${URL_PREFIX}/${body.documentId}`, body);
+    return fetch
+      .put(`/${URL_PREFIX}/${body.documentId}`, body)
+      .then(({ data }) => data)
+      .then(navigationSchema.parse);
   },
 
   purge({ documentId, withLangVersions }: { documentId?: string; withLangVersions?: boolean }) {
@@ -67,8 +70,7 @@ export const getApiClient = once((fetch: ReturnType<typeof getFetchClient>) => (
   },
 
   healthCheck() {
-    return fetch
-      .get(`/_health`);
+    return fetch.get(`/_health`);
   },
 
   healthCheckIndex() {

--- a/admin/src/pages/HomePage/hooks/index.tsx
+++ b/admin/src/pages/HomePage/hooks/index.tsx
@@ -157,7 +157,7 @@ export const useCreateNavigation = () => {
   });
 };
 
-export const useUpdateNavigation = (onSuccess?: Effect<void>) => {
+export const useUpdateNavigation = (onSuccess?: Effect<NavigationSchema>) => {
   const fetch = getFetchClient();
   const apiClient = getApiClient(fetch);
   // TODO: nicer cache update
@@ -165,11 +165,12 @@ export const useUpdateNavigation = (onSuccess?: Effect<void>) => {
 
   return useMutation({
     mutationFn: apiClient.update,
-    onSuccess() {
+    onSuccess(next) {
       queryClient.invalidateQueries({
         queryKey: apiClient.readAllIndex(),
       });
-      onSuccess?.();
+      
+      onSuccess?.(next);
     },
   });
 };

--- a/admin/src/pages/HomePage/index.tsx
+++ b/admin/src/pages/HomePage/index.tsx
@@ -222,12 +222,18 @@ const Inner = () => {
     i18nCopySourceLocale && setI18nCopyModalOpened(true);
   }, [setI18nCopyModalOpened, i18nCopySourceLocale]);
 
-  const updateNavigationMutation = useUpdateNavigation(() => {
-    setRecentNavigation({
-      documentId: currentNavigation?.documentId,
-      id: currentNavigation?.id,
+  const updateNavigationMutation = useUpdateNavigation((next) => {
+    setCurrentNavigation({
+      ...next,
+      items: next.items.map(appendViewId),
     });
-    setCurrentNavigation(undefined);
+
+    setRecentNavigation({
+      documentId: next.documentId,
+      id: next.id,
+    });
+
+    setStructureChanged(false);
   });
 
   const submit = () => {
@@ -396,7 +402,7 @@ const Inner = () => {
       setRecentNavigation(undefined);
       setCurrentNavigation(navigation ? navigation : first(navigationsQuery.data));
     }
-  }, [navigationsQuery.data]);
+  }, [navigationsQuery.data, currentNavigation]);
 
   useEffect(() => {
     if (!currentLocale && localeQuery.data?.defaultLocale) {

--- a/server/src/services/admin/admin.ts
+++ b/server/src/services/admin/admin.ts
@@ -446,7 +446,7 @@ const adminService = (context: { strapi: Core.Strapi }) => ({
       }
     }
 
-    const updatedNavigationAsDTO = await commonService
+    await commonService
       .analyzeBranch({
         navigationItems: items ?? [],
         masterEntity: currentNavigation,
@@ -461,8 +461,6 @@ const adminService = (context: { strapi: Core.Strapi }) => ({
           oldEntity: currentNavigationAsDTO,
           newEntity,
         });
-
-        return newEntity;
       });
 
     await commonService.emitEvent({
@@ -474,7 +472,11 @@ const adminService = (context: { strapi: Core.Strapi }) => ({
       uid: masterModel.uid,
     });
 
-    return updatedNavigationAsDTO;
+    return await this.getById({
+      documentId: payload.documentId,
+      locale: payload.locale,
+      populate: ['related'],
+    });
   },
 
   async delete({ auditLog, documentId }: DeleteInput): Promise<void> {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/552

## Summary

What does this PR do/solve? 

- admin ui refresh after navigation is saved

## Test Plan

- start the server
- go to navigation admin
- update a navigation
- save
- save button is reset
- no information is lost
- after next edit (addition) no extra items should be visible, no items missing