### PR TITLE
fix: migration service id in first migration

### DIFF
--- a/migrations/strapi-plugin-navigation-3.0.0-no-1-related-id-to-documentid.js
+++ b/migrations/strapi-plugin-navigation-3.0.0-no-1-related-id-to-documentid.js
@@ -34,7 +34,7 @@ module.exports = {
 
     await strapi.db.transaction(async () => {
       // Run related id to document id migration
-      await strapi.service('plugin::navigation.navigation').migrateRelatedIdToDocumentId();
+      await strapi.service('plugin::navigation.migrate').migrateRelatedIdToDocumentId();
     });
   },
 };


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/551

## Summary

What does this PR do/solve? 

- id of migration service for id to document id migration

## Test Plan

- run migration