### PR TITLE
fix: change delete method so it triggers delete event

### DIFF
--- a/server/src/repositories/navigation-item.ts
+++ b/server/src/repositories/navigation-item.ts
@@ -84,15 +84,13 @@ export const getNavigationItemRepository = once((context: { strapi: Core.Strapi 
   remove(item: NavigationItemRemoveMinimal) {
     const { itemModel } = getPluginModels(context);
 
-    return context.strapi.query(itemModel.uid).delete({ where: { documentId: item.documentId } });
+    return context.strapi.documents(itemModel.uid).delete({ documentId: item.documentId });
   },
 
   removeForIds(ids: string[]) {
     const { itemModel } = getPluginModels(context);
 
-    return context.strapi.query(itemModel.uid).deleteMany({
-      where: { documentId: ids },
-    });
+    return ids.map(id => context.strapi.documents(itemModel.uid).delete({ documentId: id }))
   },
 
   findForMasterIds(ids: number[]) {

--- a/server/src/repositories/navigation.ts
+++ b/server/src/repositories/navigation.ts
@@ -101,13 +101,13 @@ export const getNavigationRepository = once((context: { strapi: Core.Strapi }) =
     }
   },
 
-  remove(navigation: Partial<Pick<NavigationDBSchema, 'id' | 'documentId'>>) {
+  remove(navigation: Partial<Pick<NavigationDBSchema, 'documentId'>>) {
     const { masterModel } = getPluginModels(context);
 
-    if (!navigation.documentId && !navigation.id) {
-      throw new NavigationError('Some kind of id required. None given.');
+    if (!navigation.documentId) {
+      throw new NavigationError('Document id is required.');
     }
 
-    return context.strapi.query(masterModel.uid).deleteMany({ where: navigation });
+    return context.strapi.documents(masterModel.uid).delete({ documentId: navigation.documentId });
   },
 }));


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/548

## Summary

Refactored navigation item deletion to use entityService.delete to ensure lifecycle events and webhooks are properly triggered
