### PR TITLE
fix: fix order of first migration

### DIFF
--- a/migrations/strapi-plugin-navigation-3.0.0-no-1-related-id-to-documentid.js
+++ b/migrations/strapi-plugin-navigation-3.0.0-no-1-related-id-to-documentid.js
@@ -12,6 +12,13 @@ module.exports = {
     // Get all entries and rewrite directly to the navigation_items table
     const all = await knex.from(SOURCE_TABLE_NAME).columns('id', 'related_id', 'related_type').select();
     
+    await knex.schema.alterTable(
+      TARGET_TABLE_NAME,
+      function (table) {
+        table.string("related");
+      }
+    );
+
     await Promise.all(
       all.map(async (item) => {
         const { related_id, related_type, id: row_id} = item;
@@ -19,7 +26,11 @@ module.exports = {
         if (related_id && related_type && !isNaN(parseInt(related_id, 10))) {
           const newRelatedId = `${related_type}${RELATED_ITEM_SEPARATOR}${related_id}`;
           const link = await knex.from(SOURCE_LINK_TABLE_NAME).columns('navigation_item_id', 'navigations_items_related_id').select().where({ navigations_items_related_id: row_id });
-          const nav_id = link[0].navigation_item_id;
+          const nav_id = link[0]?.navigation_item_id;
+
+          if (!nav_id) {
+            return;
+          }
 
           await knex.from(TARGET_TABLE_NAME).update({ related: newRelatedId }).where({ id: nav_id });
         }
@@ -27,14 +38,9 @@ module.exports = {
     );
 
     // Drop the old tables
-    // await knex.schema.dropTable(SOURCE_TABLE_NAME);
-    // await knex.schema.dropTable(SOURCE_LINK_TABLE_NAME);
+    await knex.schema.dropTable(SOURCE_TABLE_NAME);
+    await knex.schema.dropTable(SOURCE_LINK_TABLE_NAME);
 
     console.log("Navigation plugin :: Migrations :: Backup navigation item related table - DONE");
-
-    await strapi.db.transaction(async () => {
-      // Run related id to document id migration
-      await strapi.service('plugin::navigation.migrate').migrateRelatedIdToDocumentId();
-    });
   },
 };

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -10,5 +10,7 @@ const bootstrap = async (context: { strapi: Core.Strapi }) => {
   await navigationSetup(context);
   await setupPermissions(context);
   await graphQLSetup(context);
+
+  await strapi.service('plugin::navigation.migrate').migrateRelatedIdToDocumentId();
 };
 export default bootstrap;

--- a/server/src/repositories/navigation-item.ts
+++ b/server/src/repositories/navigation-item.ts
@@ -75,6 +75,14 @@ export const getNavigationItemRepository = once((context: { strapi: Core.Strapi 
       .then((items) => items.map(removeSensitiveFields));
   },
 
+  findV4({ filters, locale, limit, order, populate }: FindInput) {
+    const { itemModel } = getPluginModels(context);
+
+    return context.strapi
+      .documents(itemModel.uid)
+      .findMany({ filters, locale, limit, populate, orderBy: order })
+  },
+
   count(where: any) {
     const { itemModel } = getPluginModels(context);
 

--- a/server/src/services/migration/migration.ts
+++ b/server/src/services/migration/migration.ts
@@ -7,10 +7,10 @@ export type MigrationService = ReturnType<typeof migrationService>;
 
 const migrationService = (context: { strapi: Core.Strapi }) => ({
   async migrateRelatedIdToDocumentId(): Promise<void> {
-    console.log('Navigation plugin :: Migrations :: Relared id to document id - START');
+    console.log('Navigation plugin :: Migrations :: Related id to document id - START');
 
     const navigationItemRepository = getNavigationItemRepository(context);
-    const all = await navigationItemRepository.find({
+    const all = await navigationItemRepository.findV4({
       filters: {},
       limit: Number.MAX_SAFE_INTEGER,
     });
@@ -40,7 +40,7 @@ const migrationService = (context: { strapi: Core.Strapi }) => ({
       })
     );
 
-    console.log('Navigation plugin :: Migrations :: Relared id to document id - DONE');
+    console.log('Navigation plugin :: Migrations :: Related id to document id - DONE');
   },
 });
 


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/549
https://github.com/VirtusLab/strapi-plugin-navigation/issues/550

## Summary

What does this PR do/solve? 

This PR resolves migration issues during the Strapi v4 to v5 upgrade by deferring custom plugin migrations after Strapi’s internal ones complete. The fix moves the custom migration logic to the `bootstrap` phase, ensuring all system tables and relations (like `*_lnk`, `*_mph`) are properly initialized before any data manipulation occurs.

## Test Plan

 - Copy the migration file to your server
 - Start the server
 - Check the admin panel
