### PR TITLE
fix: enable deletion of broken navigation items

### DIFF
--- a/admin/src/pages/HomePage/components/NavigationHeader/index.tsx
+++ b/admin/src/pages/HomePage/components/NavigationHeader/index.tsx
@@ -25,6 +25,7 @@ interface Props {
   availableNavigations: NavigationSchema[];
   structureHasErrors?: boolean;
   structureHasChanged?: boolean;
+  isSaving?: boolean;
   handleChangeSelection: Effect<NavigationSchema>;
   handleLocalizationSelection: Effect<string>;
   handleSave: Effect<void>;
@@ -42,6 +43,7 @@ export const NavigationHeader: React.FC<Props> = ({
   availableNavigations,
   structureHasErrors,
   structureHasChanged,
+  isSaving,
   handleChangeSelection,
   handleLocalizationSelection,
   handleSave,
@@ -140,7 +142,7 @@ export const NavigationHeader: React.FC<Props> = ({
                     <Button
                       onClick={handleSave}
                       startIcon={submitIcon}
-                      disabled={structureHasErrors || !structureHasChanged}
+                      disabled={structureHasErrors || !structureHasChanged || isSaving}
                       type="submit"
                       fullWidth
                       size="S"

--- a/admin/src/pages/HomePage/index.tsx
+++ b/admin/src/pages/HomePage/index.tsx
@@ -453,6 +453,7 @@ const Inner = () => {
           handleSave={submit}
           locale={localeQuery.data}
           structureHasChanged={structureChanged}
+          isSaving={updateNavigationMutation.isPending}
           permissions={{ canUpdate }}
           currentLocale={currentLocale}
         />

--- a/server/src/services/common/utils.ts
+++ b/server/src/services/common/utils.ts
@@ -7,6 +7,7 @@ export interface DuplicateCheckItem {
   title: string;
   path?: string | null;
   type: NavigationItemType;
+  removed?: boolean;
 }
 
 export const checkDuplicatePath = ({
@@ -20,7 +21,7 @@ export const checkDuplicatePath = ({
     if (parentItem && parentItem.items) {
       for (let item of checkData) {
         for (let _ of parentItem.items) {
-          if (_.path === item.path && _.id !== item.id && item.type === 'INTERNAL') {
+          if (_.path === item.path && _.id !== item.id && item.type === 'INTERNAL' && !_.removed) {
             return reject(
               new NavigationError(
                 `Duplicate path:${item.path} in parent: ${parentItem.title || 'root'} for ${item.title} and ${_.title} items`,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/562

## Summary

What does this PR do/solve? 

 - Enables deletion of broken navigation items (with duplicated paths)
 - Disables the `Save` button while the server is processing the navigation save request.

**Note**: To delete navigation items, the user must remove all broken items in the branch. For example, if there are three navigation items with the same `path`, the user needs to delete at least two of them. An example is shown in the attached video.

https://github.com/user-attachments/assets/f1066bf2-12ad-4e2f-9b69-99ba1fdc51f7

