### PR TITLE
fix: internal navigation item ui schema

### DIFF
--- a/admin/src/pages/HomePage/components/NavigationItemForm/utils/form.ts
+++ b/admin/src/pages/HomePage/components/NavigationItemForm/utils/form.ts
@@ -89,7 +89,7 @@ const navigationInternalItemFormSchema = ({
   }).extend({
     type: z.literal('INTERNAL'),
     path: z.string(),
-    externalPath: z.string().optional(),
+    externalPath: z.string().nullish(),
     relatedType: z.string(),
     related: isSingleSelected ? z.string().optional() : z.string(),
   });


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-navigation/issues/560

## Summary

On switch from `wrapper` to `internal` item, item cannot be saved. This happens for saved items. The issue is `externalPath` field being set to `null`. What is expected is `string` or `undefined`. I made validator to accept ale `null`

## Test Plan

- start server
- go to admin
- add a `wrapper` item 
- save navigation
- change `wrapper` item to `internal`
- save item and navigation