### PR TITLE
fix: update navigation when new locale is created

### DIFF
--- a/admin/src/pages/HomePage/components/ChangeLanguageDialog/index.tsx
+++ b/admin/src/pages/HomePage/components/ChangeLanguageDialog/index.tsx
@@ -26,7 +26,9 @@ export const ChangeLanguageDialog: FC<Props> = ({ onConfirm, onCancel }) => {
     <ConfirmationDialog
       isVisible
       header={formatMessage(getTrad('pages.view.actions.changeLanguage.confirmation.header'))}
-      labelConfirm={formatMessage(getTrad('pages.view.actions.changeLanguage.confirmation.confirm'))}
+      labelConfirm={formatMessage(
+        getTrad('pages.view.actions.changeLanguage.confirmation.confirm')
+      )}
       iconConfirm={refreshIcon}
       mainIcon={refreshIcon}
       onConfirm={onConfirm}

--- a/admin/src/pages/HomePage/hooks/index.tsx
+++ b/admin/src/pages/HomePage/hooks/index.tsx
@@ -73,6 +73,28 @@ export const useResetContentTypes = () => {
   };
 };
 
+export const useInvalidateNavigations = () => {
+  const fetch = getFetchClient();
+  const apiClient = getApiClient(fetch);
+
+  const queryClient = useQueryClient();
+
+  return () => {
+    queryClient.invalidateQueries({
+      queryKey: apiClient.readAllIndex(),
+    });
+  };
+};
+
+export const useInvalidateLocale = () => {
+  const fetch = getFetchClient();
+  const apiClient = getApiClient(fetch);
+
+  const queryClient = useQueryClient();
+
+  return () => queryClient.invalidateQueries({ queryKey: apiClient.readLocaleIndex() });
+};
+
 export const useNavigations = () => {
   const fetch = getFetchClient();
   const apiClient = getApiClient(fetch);

--- a/admin/src/translations/en.ts
+++ b/admin/src/translations/en.ts
@@ -451,11 +451,11 @@ const en = {
         },
         changeLanguage: {
           confirmation: {
-            header: "Confirmation",
-            confirm: "Continue",
-            content: "You have some unsaved changes. Do you want to continue?"
-          }
-        }
+            header: 'Confirmation',
+            confirm: 'Continue',
+            content: 'You have some unsaved changes. Do you want to continue?',
+          },
+        },
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-navigation",
-  "version": "3.0.16",
+  "version": "3.0.17",
   "description": "Strapi - Navigation plugin",
   "strapi": {
     "name": "navigation",

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -4,6 +4,7 @@ import { configSetup } from './config';
 import { navigationSetup } from './i18n';
 import { setupPermissions } from './permissions';
 import { graphQLSetup } from './graphql';
+import { getPluginService } from './utils';
 
 const bootstrap = async (context: { strapi: Core.Strapi }) => {
   await configSetup(context);
@@ -12,5 +13,13 @@ const bootstrap = async (context: { strapi: Core.Strapi }) => {
   await graphQLSetup(context);
 
   await strapi.service('plugin::navigation.migrate').migrateRelatedIdToDocumentId();
+
+  strapi.db.lifecycles.subscribe({
+    models: ['plugin::i18n.locale'],
+    async afterCreate(event) {
+      const adminService = getPluginService(context, 'admin');
+      await adminService.refreshNavigationLocale(event.result?.code);
+    },
+  });
 };
 export default bootstrap;

--- a/server/src/services/admin/admin.ts
+++ b/server/src/services/admin/admin.ts
@@ -540,6 +540,35 @@ const adminService = (context: { strapi: Core.Strapi }) => ({
     await commonService.setDefaultConfig();
   },
 
+  async refreshNavigationLocale(newLocale?: string): Promise<void> {
+    if (!newLocale) {
+      return;
+    }
+
+    const commonService = getPluginService(context, 'common');
+
+    const { defaultLocale } = await commonService.readLocale();
+
+    const repository = getNavigationRepository(context);
+
+    const navigations = await repository.find({
+      limit: Number.MAX_SAFE_INTEGER,
+      locale: defaultLocale,
+    });
+
+    await Promise.all(
+      navigations.map(({ name, visible, slug, documentId }) =>
+        repository.save({
+          name,
+          visible,
+          locale: newLocale,
+          slug,
+          documentId,
+        })
+      )
+    );
+  },
+
   async updateConfig({ config: newConfig }: UpdateConfigInput): Promise<void> {
     const commonService = getPluginService(context, 'common');
 


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/567

## Summary

 - creates a new navigation entry with a new locale, when a new language is added to the Strapi Internationalization