### PR TITLE
fix: migration deletion in wrong order

### DIFF
--- a/admin/src/api/validators.ts
+++ b/admin/src/api/validators.ts
@@ -18,7 +18,7 @@ const navigationItemBaseSchema = z.object({
   documentId: z.string(),
   title: z.string(),
   type: navigationItemTypeSchema,
-  path: z.string(),
+  path: z.string().or(z.null()).optional(),
   externalPath: z.string().or(z.null()).optional(),
   uiRouterKey: z.string(),
   menuAttached: z.boolean(),

--- a/admin/src/pages/HomePage/components/NavigationItemForm/utils/form.ts
+++ b/admin/src/pages/HomePage/components/NavigationItemForm/utils/form.ts
@@ -91,7 +91,7 @@ const navigationInternalItemFormSchema = ({
     isSingleSelected,
   }).extend({
     type: z.literal('INTERNAL'),
-    path: z.string(),
+    path: z.string().or(z.null()).optional(),
     externalPath: z.string().nullish(),
     relatedType: z.string(),
     related: isSingleSelected ? z.string().optional() : z.string(),

--- a/migrations/strapi-plugin-navigation-3.0.0-no-1-related-id-to-documentid.js
+++ b/migrations/strapi-plugin-navigation-3.0.0-no-1-related-id-to-documentid.js
@@ -42,10 +42,6 @@ module.exports = {
       })
     );
 
-    // Drop the old tables
-    await knex.schema.dropTable(SOURCE_TABLE_NAME);
-    await knex.schema.dropTable(SOURCE_LINK_TABLE_NAME);
-
     console.log('Navigation plugin :: Migrations :: Backup navigation item related table - DONE');
   },
 };


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/577

## Summary

 - Remove dropping tables from the 1st migration as internal Strapi migrations handle them
 - Make `path` optional (in the previous version of the plugin, external links had path set to null, which can break loading of the navigation in case of migrating them)

## Test Plan

 - Run a Strapi with a database in v4 with 1st migration added to `database/migration` folder
