### PR TITLE
fix: search in media library

### DIFF
--- a/admin/src/pages/HomePage/components/NavigationItemForm/index.tsx
+++ b/admin/src/pages/HomePage/components/NavigationItemForm/index.tsx
@@ -30,6 +30,8 @@ import { AdditionalFields } from './components/AdditionalFields';
 import { CopyFromLocales } from './components/CopyFromLocales';
 import { RelatedTypeField } from './components/RelatedTypeField';
 import { RelatedEntityField } from './components/RelatedEntityField';
+import { Combobox } from '@strapi/design-system';
+import { Box } from '@strapi/design-system';
 
 export { ContentTypeEntity, GetContentTypeEntitiesPayload } from './types';
 export { NavigationItemFormSchema } from './utils/form';
@@ -258,7 +260,15 @@ export const NavigationItemForm: React.FC<NavigationItemFormProps> = ({
                     />
                   </Grid.Root>
                 )}
-
+                {/* Strapi Design System inside modals can cause unstable focus (esp. in MediaLibrary) due to Radix-UI focus handling. 
+                Wrapping with Combobox (which uses FocusScope) prevents infinite focus bouncing. */}
+                {values.type !== 'INTERNAL' && (
+                  <Grid.Root display="none">
+                    <Box display="none">
+                      <Combobox />
+                    </Box>
+                  </Grid.Root>
+                )}
                 <AdditionalFields />
 
                 <CopyFromLocales

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-navigation",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Strapi - Navigation plugin",
   "strapi": {
     "name": "navigation",


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-navigation/issues/596

## Summary

Enables media search functionality for custom fields in navigation items of type `Wrapper` and `External`, ensuring the Media Library works consistently across all navigation item types.

## Test Plan

 - add a custom field in type media
 - go to the add navigation item form
 - change the navigation item type to `wrapper` or `external`
 - try to add media
 - check if you can search in media library input
